### PR TITLE
Initialize empty files as new databases

### DIFF
--- a/src/storage/page_manager.zig
+++ b/src/storage/page_manager.zig
@@ -89,7 +89,11 @@ pub const PageManager = struct {
 
         const file_size = file.size() catch return PageManagerError.IoError;
 
-        if (file_size == 0 and options.create) {
+        if (file_size == 0) {
+            // Empty file - initialize as new database (like SQLite behavior)
+            if (options.read_only) {
+                return PageManagerError.InvalidHeader;
+            }
             try self.initNewFile();
         } else if (file_size >= DEFAULT_PAGE_SIZE) {
             try self.loadHeader();


### PR DESCRIPTION
When opening an existing file that is empty (0 bytes), automatically initialize it as a new database instead of returning InvalidHeader. This matches SQLite's behavior and provides a better user experience.

Read-only opens of empty files still fail, as you cannot create a database without write permission.