### PR TITLE
Handle oversized payloads, fix FTS cleanup fallback, and add label lookup APIs

### DIFF
--- a/bindings/go/db.go
+++ b/bindings/go/db.go
@@ -167,6 +167,25 @@ func (db *DB) CacheStats() (QueryCacheStats, error) {
 	}, nil
 }
 
+// GetNodesByLabel returns every node id that currently carries label.
+// An unknown label is not an error and yields an empty slice.
+func (db *DB) GetNodesByLabel(label string) ([]NodeID, error) {
+	if db == nil || db.raw == nil {
+		return nil, ErrDatabaseClosed
+	}
+
+	ids, err := db.raw.GetNodesByLabel(label)
+	if err != nil {
+		return nil, wrapError(err)
+	}
+
+	out := make([]NodeID, len(ids))
+	for i, id := range ids {
+		out[i] = NodeID(id)
+	}
+	return out, nil
+}
+
 func (db *DB) VectorSearch(vector []float32, opts VectorSearchOptions) ([]VectorSearchResult, error) {
 	if db == nil || db.raw == nil {
 		return nil, ErrDatabaseClosed

--- a/bindings/go/internal/cgo/bridge.go
+++ b/bindings/go/internal/cgo/bridge.go
@@ -537,6 +537,36 @@ func (tx *Tx) Query(cypher string, params map[string]any) (QueryResult, error) {
 	return result.materialize()
 }
 
+func (db *DB) GetNodesByLabel(label string) ([]uint64, error) {
+	var labelPtr *C.char
+	if len(label) > 0 {
+		labelPtr = (*C.char)(C.CBytes([]byte(label)))
+		defer C.free(unsafe.Pointer(labelPtr))
+	}
+
+	var idsPtr *C.lattice_node_id
+	var count C.size_t
+	if err := errorFromCode(ErrorCode(C.lattice_get_nodes_by_label(
+		db.ptr,
+		labelPtr,
+		C.size_t(len(label)),
+		&idsPtr,
+		&count,
+	))); err != nil {
+		return nil, err
+	}
+	if count == 0 || idsPtr == nil {
+		return []uint64{}, nil
+	}
+	defer C.lattice_free_node_ids(idsPtr, count)
+
+	n := int(count)
+	src := unsafe.Slice((*uint64)(unsafe.Pointer(idsPtr)), n)
+	out := make([]uint64, n)
+	copy(out, src)
+	return out, nil
+}
+
 func (db *DB) VectorSearch(vector []float32, k uint32, efSearch uint16) ([]VectorSearchResult, error) {
 	var vectorPtr *C.float
 	if len(vector) > 0 {

--- a/bindings/python/src/latticedb/_bindings.py
+++ b/bindings/python/src/latticedb/_bindings.py
@@ -514,6 +514,23 @@ class LatticeLib:
         ]
         self._lib.lattice_node_get_labels.restype = c_int
 
+        # lattice_get_nodes_by_label
+        self._lib.lattice_get_nodes_by_label.argtypes = [
+            LatticeDatabase,
+            c_char_p,
+            c_size_t,
+            POINTER(POINTER(LatticeNodeId)),
+            POINTER(c_size_t),
+        ]
+        self._lib.lattice_get_nodes_by_label.restype = c_int
+
+        # lattice_free_node_ids
+        self._lib.lattice_free_node_ids.argtypes = [
+            POINTER(LatticeNodeId),
+            c_size_t,
+        ]
+        self._lib.lattice_free_node_ids.restype = None
+
         # lattice_free_string
         self._lib.lattice_free_string.argtypes = [c_char_p]
         self._lib.lattice_free_string.restype = None

--- a/bindings/python/src/latticedb/database.py
+++ b/bindings/python/src/latticedb/database.py
@@ -272,6 +272,37 @@ class Database:
             if query_ptr.value:
                 lib._lib.lattice_query_free(query_ptr)
 
+    def get_nodes_by_label(self, label: str) -> List[int]:
+        """
+        Return every node id that currently carries ``label``.
+
+        An unknown label is not an error and returns an empty list.
+        """
+        if self._handle is None:
+            raise RuntimeError("Database is not open")
+
+        lib = get_lib()
+        label_bytes = label.encode("utf-8")
+        ids_ptr = ctypes.POINTER(LatticeNodeId)()
+        count = ctypes.c_size_t(0)
+
+        code = lib._lib.lattice_get_nodes_by_label(
+            self._handle,
+            label_bytes,
+            len(label_bytes),
+            byref(ids_ptr),
+            byref(count),
+        )
+        check_error(code)
+
+        try:
+            if count.value == 0 or not ids_ptr:
+                return []
+            return [ids_ptr[i] for i in range(count.value)]
+        finally:
+            if ids_ptr:
+                lib._lib.lattice_free_node_ids(ids_ptr, count.value)
+
     def vector_search(
         self,
         vector: "NDArray[np.float32]",

--- a/bindings/typescript/src/database.ts
+++ b/bindings/typescript/src/database.ts
@@ -212,6 +212,16 @@ export class Database {
   }
 
   /**
+   * Return every node id that currently carries `label`.
+   *
+   * An unknown label is not an error and yields an empty array.
+   */
+  async getNodesByLabel(label: string): Promise<bigint[]> {
+    this.ensureOpen();
+    return this.ffi!.getNodesByLabel(this.dbHandle!, label);
+  }
+
+  /**
    * Search for similar vectors.
    *
    * @param vector - Query vector

--- a/bindings/typescript/src/ffi/bindings.ts
+++ b/bindings/typescript/src/ffi/bindings.ts
@@ -181,6 +181,14 @@ export interface LatticeBindings {
     node_id: bigint,
     labels_out: unknown[]
   ) => number;
+  lattice_get_nodes_by_label: (
+    db: unknown,
+    label: string | null,
+    label_len: number,
+    node_ids_out: unknown[],
+    count_out: number[]
+  ) => number;
+  lattice_free_node_ids: (node_ids: unknown, count: number) => void;
   lattice_free_string: (str: unknown) => void;
   lattice_value_free: (value: unknown) => void;
   lattice_node_set_property: (
@@ -483,6 +491,17 @@ function createBindings(): LatticeBindings {
       TxnPtr,
       'uint64', // node_id
       koffi.out(koffi.pointer('void*')), // labels_out - raw pointer for manual free
+    ]),
+    lattice_get_nodes_by_label: lib.func('lattice_get_nodes_by_label', 'int', [
+      DatabasePtr,
+      'str', // label
+      'size_t', // label_len
+      koffi.out(koffi.pointer('void*')), // node_ids_out - raw pointer for manual free
+      koffi.out(koffi.pointer('size_t')), // count_out
+    ]),
+    lattice_free_node_ids: lib.func('lattice_free_node_ids', 'void', [
+      'void*',
+      'size_t',
     ]),
     lattice_free_string: lib.func('lattice_free_string', 'void', ['void*']),
     lattice_value_free: lib.func('lattice_value_free', 'void', [ValuePtr]),

--- a/bindings/typescript/src/ffi/index.ts
+++ b/bindings/typescript/src/ffi/index.ts
@@ -321,6 +321,36 @@ export class LatticeFFI {
   }
 
   /**
+   * Return every node id that currently carries `label`. An unknown label
+   * is not an error and yields an empty array.
+   */
+  getNodesByLabel(db: DatabaseHandle, label: string): bigint[] {
+    const labelBytes = Buffer.byteLength(label, 'utf8');
+    const idsOut: unknown[] = [null];
+    const countOut = [0];
+    const err = this.bindings.lattice_get_nodes_by_label(
+      db,
+      label,
+      labelBytes,
+      idsOut,
+      countOut
+    );
+    this.checkError(err);
+
+    const ptr = idsOut[0];
+    const count = countOut[0] ?? 0;
+    if (!ptr || count === 0) {
+      return [];
+    }
+
+    try {
+      return koffi.decode(ptr, 'uint64', count) as bigint[];
+    } finally {
+      this.bindings.lattice_free_node_ids(ptr, count);
+    }
+  }
+
+  /**
    * Set a vector on a node.
    */
   setVector(

--- a/build.zig
+++ b/build.zig
@@ -5,8 +5,10 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    // Create the main library module
-    const lib_module = b.createModule(.{
+    // Create the main library module — exposed publicly via b.addModule so
+    // sibling Zig packages can consume it as `dep.module("lattice")` without
+    // going through the C ABI header.
+    const lib_module = b.addModule("lattice", .{
         .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,

--- a/include/lattice.h
+++ b/include/lattice.h
@@ -235,6 +235,21 @@ lattice_error lattice_node_get_labels(
     char** labels_out
 );
 
+/* Return every node id that currently carries `label`. On success the
+ * caller owns `*node_ids_out` and must release it with
+ * lattice_free_node_ids(ids, count). An unknown label is not an error
+ * and yields count=0 with node_ids_out=NULL. */
+lattice_error lattice_get_nodes_by_label(
+    lattice_database* db,
+    const char* label,
+    size_t label_len,
+    lattice_node_id** node_ids_out,
+    size_t* count_out
+);
+
+/* Free an array returned by lattice_get_nodes_by_label. */
+void lattice_free_node_ids(lattice_node_id* node_ids, size_t count);
+
 /* Free a string allocated by lattice (e.g., from lattice_node_get_labels) */
 void lattice_free_string(char* str);
 

--- a/src/api/c_api.zig
+++ b/src/api/c_api.zig
@@ -280,6 +280,10 @@ fn mapDatabaseError(err: DatabaseError) lattice_error {
         DatabaseError.TransactionNotActive => .err_invalid_arg,
         DatabaseError.TransactionReadOnly => .err_read_only,
         DatabaseError.TransactionsNotEnabled => .err_invalid_arg,
+        // Node/edge payload too big for one btree leaf page. No dedicated
+        // C enum value exists yet; `err_full` signals "cannot fit" as
+        // close as possible until the ABI is versioned.
+        DatabaseError.ValueTooLarge => .err_full,
     };
 }
 
@@ -1109,6 +1113,56 @@ pub export fn lattice_node_exists(
         };
     };
     return .ok;
+}
+
+/// Return every node id that currently carries `label`. On success writes
+/// a heap-allocated array of node ids into `node_ids_out` and its element
+/// count into `count_out`; the caller must release it with
+/// `lattice_free_node_ids`. An unknown label is not an error and yields
+/// `count_out = 0` with `node_ids_out = null`.
+pub export fn lattice_get_nodes_by_label(
+    db: ?*lattice_database,
+    label: [*c]const u8,
+    label_len: usize,
+    node_ids_out: *?[*]lattice_node_id,
+    count_out: *usize,
+) lattice_error {
+    const db_handle = toHandle(DatabaseHandle, db) orelse return .err_invalid_arg;
+    if (label == null) return .err_invalid_arg;
+
+    node_ids_out.* = null;
+    count_out.* = 0;
+
+    const label_slice = label[0..label_len];
+    const owned = db_handle.db.getNodesByLabel(label_slice) catch |err| {
+        return mapDatabaseError(err);
+    };
+
+    if (owned.len == 0) {
+        db_handle.db.allocator.free(owned);
+        return .ok;
+    }
+
+    // `getNodesByLabel` hands back a slice owned by the database allocator.
+    // Copy it into a `global_allocator` buffer so `lattice_free_node_ids`
+    // can release it without coupling the caller to lattice internals.
+    const out = global_allocator.alloc(lattice_node_id, owned.len) catch {
+        db_handle.db.allocator.free(owned);
+        return .err_out_of_memory;
+    };
+    @memcpy(out, owned);
+    db_handle.db.allocator.free(owned);
+
+    node_ids_out.* = out.ptr;
+    count_out.* = out.len;
+    return .ok;
+}
+
+/// Free an array returned by `lattice_get_nodes_by_label`.
+pub export fn lattice_free_node_ids(node_ids: ?[*]lattice_node_id, count: usize) void {
+    const ptr = node_ids orelse return;
+    if (count == 0) return;
+    global_allocator.free(ptr[0..count]);
 }
 
 /// Get labels for a node as comma-separated string

--- a/src/fts/index.zig
+++ b/src/fts/index.zig
@@ -306,8 +306,25 @@ pub const FtsIndex = struct {
                 idx += 1;
             }
 
-            ri.setDocTerms(doc_id, term_slice) catch {
-                return FtsError.IoError;
+            // Skip populating the reverse index when the serialized term
+            // list would exceed a single btree leaf page. The document
+            // stays queryable via the forward posting lists; only future
+            // `removeDocument(doc_id)` calls for this specific doc will
+            // need to walk the dictionary as a fallback instead of using
+            // the reverse-index shortcut. Treating this as fatal used to
+            // propagate a bare IoError back to callers that index
+            // multi-KiB markdown content, which is precisely the
+            // nullclaw onboard-scaffold workload.
+            ri.setDocTerms(doc_id, term_slice) catch |err| switch (err) {
+                reverse_index_mod.ReverseIndexError.ValueTooLarge => {
+                    std.log.warn(
+                        "fts: reverse_index too large for doc={d}, terms={d}; " ++
+                            "future removeDocument will fall back to dictionary scan",
+                        .{ doc_id, num_terms },
+                    );
+                },
+                reverse_index_mod.ReverseIndexError.OutOfMemory => return FtsError.OutOfMemory,
+                else => return FtsError.IoError,
             };
         }
 
@@ -326,45 +343,47 @@ pub const FtsIndex = struct {
         // If we have a reverse index, do proper cleanup
         if (self.reverse_index) |*ri| {
             // 1. Get terms from reverse index
-            const terms = ri.getDocTerms(doc_id) catch {
+            if (ri.getDocTerms(doc_id) catch {
                 return FtsError.IoError;
-            } orelse {
-                // Document not in reverse index, just remove doc length
-                self.doc_lengths.removeDoc(doc_id) catch |err| {
+            }) |terms| {
+                defer ri.freeTerms(terms);
+
+                // 2. For each term, remove from posting list and update dictionary
+                for (terms) |term| {
+                    const entry = self.dictionary.get(term) catch continue orelse continue;
+
+                    if (entry.posting_page != 0) {
+                        const result = self.posting_store.removeEntry(entry.posting_page, doc_id) catch continue;
+                        if (result.found) {
+                            // Update dictionary statistics - track failures
+                            self.dictionary.decrementDocFreq(term) catch {
+                                stats_update_failed = true;
+                            };
+                            self.dictionary.subtractTotalFreq(term, result.term_freq) catch {
+                                stats_update_failed = true;
+                            };
+                        }
+                    }
+                }
+
+                // 3. Remove reverse index entry
+                ri.removeDoc(doc_id) catch |err| {
                     return switch (err) {
                         error.OutOfMemory => FtsError.OutOfMemory,
                         else => FtsError.IoError,
                     };
                 };
-                return;
-            };
-            defer ri.freeTerms(terms);
-
-            // 2. For each term, remove from posting list and update dictionary
-            for (terms) |term| {
-                const entry = self.dictionary.get(term) catch continue orelse continue;
-
-                if (entry.posting_page != 0) {
-                    const result = self.posting_store.removeEntry(entry.posting_page, doc_id) catch continue;
-                    if (result.found) {
-                        // Update dictionary statistics - track failures
-                        self.dictionary.decrementDocFreq(term) catch {
-                            stats_update_failed = true;
-                        };
-                        self.dictionary.subtractTotalFreq(term, result.term_freq) catch {
-                            stats_update_failed = true;
-                        };
-                    }
-                }
-            }
-
-            // 3. Remove reverse index entry
-            ri.removeDoc(doc_id) catch |err| {
-                return switch (err) {
-                    error.OutOfMemory => FtsError.OutOfMemory,
-                    else => FtsError.IoError,
+            } else {
+                // Reverse index has no entry for this doc. This happens when
+                // indexDocument skipped populating it because the serialized
+                // term list exceeded a single btree leaf page. Fall back to a
+                // full dictionary scan so stale posting entries for doc_id do
+                // not survive removal (and resurrect on re-index under the
+                // same id).
+                self.removeDocumentByDictionaryScan(doc_id, &stats_update_failed) catch |err| {
+                    return err;
                 };
-            };
+            }
         }
 
         // 4. Remove from doc lengths (this updates stats)
@@ -379,6 +398,70 @@ pub const FtsIndex = struct {
         // The document is removed but stats may be inconsistent
         if (stats_update_failed) {
             return FtsError.DictionaryError;
+        }
+    }
+
+    /// Fallback cleanup path used when the reverse index has no terms for
+    /// `doc_id` (indexDocument skipped populating it because the term list
+    /// was too large for a single btree leaf). Walks the entire dictionary
+    /// and removes any posting entries referencing `doc_id`, keeping
+    /// dictionary stats consistent.
+    ///
+    /// We cannot mutate the dictionary tree while iterating it, so this is
+    /// done in two phases: collect a snapshot of (term, posting_page) pairs
+    /// first, then apply removals afterwards. The work is O(|dictionary|),
+    /// but this path only fires for oversized documents on removal.
+    fn removeDocumentByDictionaryScan(
+        self: *Self,
+        doc_id: DocId,
+        stats_update_failed: *bool,
+    ) FtsError!void {
+        const PostingRef = struct {
+            term: []u8,
+            posting_page: lattice.core.types.PageId,
+        };
+
+        var refs: ArrayListUnmanaged(PostingRef) = .empty;
+        defer {
+            for (refs.items) |ref| {
+                self.allocator.free(ref.term);
+            }
+            refs.deinit(self.allocator);
+        }
+
+        {
+            var iter = self.dictionary.iterate() catch {
+                return FtsError.DictionaryError;
+            };
+            defer iter.deinit();
+
+            while (iter.next() catch {
+                return FtsError.DictionaryError;
+            }) |item| {
+                if (item.entry.posting_page == 0) continue;
+                const term_copy = self.allocator.dupe(u8, item.term) catch {
+                    return FtsError.OutOfMemory;
+                };
+                refs.append(self.allocator, .{
+                    .term = term_copy,
+                    .posting_page = item.entry.posting_page,
+                }) catch {
+                    self.allocator.free(term_copy);
+                    return FtsError.OutOfMemory;
+                };
+            }
+        }
+
+        for (refs.items) |ref| {
+            const result = self.posting_store.removeEntry(ref.posting_page, doc_id) catch continue;
+            if (!result.found) continue;
+
+            self.dictionary.decrementDocFreq(ref.term) catch {
+                stats_update_failed.* = true;
+            };
+            self.dictionary.subtractTotalFreq(ref.term, result.term_freq) catch {
+                stats_update_failed.* = true;
+            };
         }
     }
 
@@ -1799,6 +1882,65 @@ test "fts index basic" {
     const results4 = try index.search("elephant", 10);
     defer index.freeResults(results4);
     try std.testing.expectEqual(@as(usize, 0), results4.len);
+}
+
+test "fts indexDocument survives large (>=9 KiB) documents" {
+    // Regression: a ~9 KiB document tripped an integer-overflow panic
+    // somewhere in the tokenize→posting→dictionary pipeline when called
+    // from nullclaw's memory engine (SOUL.md → AGENTS.md scaffold).
+    // This test indexes progressively larger synthetic documents and
+    // asserts that each completes cleanly so the panic surfaces in CI.
+    const allocator = std.testing.allocator;
+
+    const vfs = lattice.storage.vfs;
+    const page_manager = lattice.storage.page_manager;
+
+    var posix_vfs = vfs.PosixVfs.init(allocator);
+    const vfs_impl = posix_vfs.vfs();
+
+    const db_path = "/tmp/lattice_fts_large_doc_test.db";
+    vfs_impl.delete(db_path) catch {};
+
+    var pm = try page_manager.PageManager.init(allocator, vfs_impl, db_path, .{ .create = true });
+    defer {
+        pm.deinit();
+        vfs_impl.delete(db_path) catch {};
+    }
+
+    var bp = try BufferPool.init(allocator, &pm, 64 * 4096);
+    defer bp.deinit();
+
+    var dict_tree = try BTree.init(allocator, &bp);
+    var lengths_tree = try BTree.init(allocator, &bp);
+
+    var index = FtsIndex.init(allocator, &bp, &dict_tree, &lengths_tree, null, .{});
+
+    // Build a synthetic document whose token vocabulary and total token
+    // count both scale with `word_count`, so any cumulative-state bug in
+    // posting lists, dictionary BTree inserts, or skip-pointer rollover
+    // becomes visible.
+    var doc: std.ArrayListUnmanaged(u8) = .empty;
+    defer doc.deinit(allocator);
+
+    const sizes = [_]usize{ 256, 1024, 4096, 9242, 16384 };
+    var doc_id: u64 = 1;
+    for (sizes) |target_bytes| {
+        doc.clearRetainingCapacity();
+        var seed: usize = 0;
+        while (doc.items.len < target_bytes) : (seed += 1) {
+            // Vocabulary grows with seed (`wordXXXX`), so each run adds
+            // fresh dictionary entries plus repeats of earlier words.
+            var word_buf: [32]u8 = undefined;
+            const word = std.fmt.bufPrint(&word_buf, "word{d} ", .{seed}) catch unreachable;
+            try doc.appendSlice(allocator, word);
+        }
+        const n = try index.indexDocument(doc_id, doc.items[0..@min(doc.items.len, target_bytes)]);
+        try std.testing.expect(n > 0);
+        doc_id += 1;
+    }
+
+    const stats = index.getStats();
+    try std.testing.expect(stats.total_docs == sizes.len);
 }
 
 test "fts OR query" {

--- a/src/fts/reverse_index.zig
+++ b/src/fts/reverse_index.zig
@@ -93,6 +93,13 @@ pub const ReverseIndex = struct {
             offset += term.len;
         }
 
+        // Check up-front that the btree leaf page can hold this entry
+        // so we can return a specific ValueTooLarge error without leaving
+        // the reverse index in a half-deleted state.
+        if (!self.tree.canFitLeafEntry(&key_buf, value_buf.len)) {
+            return ReverseIndexError.ValueTooLarge;
+        }
+
         // Delete existing entry first (ignore NotFound)
         self.tree.delete(&key_buf) catch |err| {
             if (err != BTreeError.KeyNotFound) {

--- a/src/graph/node.zig
+++ b/src/graph/node.zig
@@ -110,11 +110,8 @@ pub const NodeStore = struct {
         const node_id = self.next_id;
         self.next_id += 1;
 
-        // Serialize node data
-        var buf: [4096]u8 = undefined;
-        const serialized = serializeNode(labels, properties, &buf) catch {
-            return NodeError.BufferTooSmall;
-        };
+        const serialized = try self.serializeNodeAlloc(labels, properties);
+        defer self.allocator.free(serialized);
 
         // Create key from node_id
         var key_buf: [8]u8 = undefined;
@@ -141,11 +138,8 @@ pub const NodeStore = struct {
             self.next_id = node_id + 1;
         }
 
-        // Serialize node data
-        var buf: [4096]u8 = undefined;
-        const serialized = serializeNode(labels, properties, &buf) catch {
-            return NodeError.BufferTooSmall;
-        };
+        const serialized = try self.serializeNodeAlloc(labels, properties);
+        defer self.allocator.free(serialized);
 
         // Create key from node_id
         var key_buf: [8]u8 = undefined;
@@ -155,6 +149,26 @@ pub const NodeStore = struct {
         self.tree.insert(&key_buf, serialized) catch |err| {
             return mapBTreeError(err);
         };
+    }
+
+    /// Heap-allocate and serialize a node's labels + properties.
+    /// Replaces the previous fixed 4 KiB stack buffer, which capped the
+    /// total serialized node size (and therefore also limited how much
+    /// content a single STRING/BYTES property could carry). Caller owns
+    /// the returned slice.
+    fn serializeNodeAlloc(
+        self: *Self,
+        labels: []const SymbolId,
+        properties: []const Property,
+    ) NodeError![]u8 {
+        const size = serializedNodeSize(labels, properties);
+        const buf = self.allocator.alloc(u8, size) catch return NodeError.OutOfMemory;
+        errdefer self.allocator.free(buf);
+        const written = serializeNode(labels, properties, buf) catch {
+            return NodeError.BufferTooSmall;
+        };
+        if (written.len != size) return NodeError.InvalidData;
+        return buf;
     }
 
     /// Get a node by ID
@@ -190,18 +204,20 @@ pub const NodeStore = struct {
             return NodeError.NotFound;
         }
 
-        // Delete the old entry
+        // Serialize new data AND bail out up-front if it is too big for
+        // a single btree leaf page. Doing the size check before the
+        // delete keeps the store consistent if an oversized update is
+        // rejected: the existing node is still reachable and callers see
+        // a clean `BufferTooSmall` error.
+        const serialized = try self.serializeNodeAlloc(labels, properties);
+        defer self.allocator.free(serialized);
+        if (!self.tree.canFitLeafEntry(&key_buf, serialized.len)) {
+            return NodeError.BufferTooSmall;
+        }
+
         self.tree.delete(&key_buf) catch |err| {
             return mapBTreeError(err);
         };
-
-        // Serialize new data
-        var buf: [4096]u8 = undefined;
-        const serialized = serializeNode(labels, properties, &buf) catch {
-            return NodeError.BufferTooSmall;
-        };
-
-        // Insert the new data
         self.tree.insert(&key_buf, serialized) catch |err| {
             return mapBTreeError(err);
         };
@@ -234,6 +250,42 @@ pub const NodeStore = struct {
 // ============================================================================
 // Serialization
 // ============================================================================
+
+/// Exact byte count that `serializeNode` will emit for the given inputs.
+/// Mirrors the wire format below so callers can allocate exact-fit
+/// buffers instead of guessing with a fixed stack array.
+fn serializedNodeSize(labels: []const SymbolId, properties: []const Property) usize {
+    // 2 (labels.len) + labels.len * 2 + 2 (properties.len)
+    var size: usize = 2 + labels.len * 2 + 2;
+    for (properties) |prop| {
+        size += 2; // key_id u16
+        size += serializedValueSize(prop.value);
+    }
+    return size;
+}
+
+/// Exact byte count that `serializeValue` will emit for a PropertyValue.
+fn serializedValueSize(value: PropertyValue) usize {
+    return switch (value) {
+        .null_val => 1,
+        .bool_val => 2,
+        .int_val => 9,
+        .float_val => 9,
+        .string_val => |s| 5 + s.len,
+        .bytes_val => |b| 5 + b.len,
+        .vector_val => |v| 5 + v.len * 4,
+        .list_val => |list| blk: {
+            var s: usize = 5;
+            for (list) |item| s += serializedValueSize(item);
+            break :blk s;
+        },
+        .map_val => |map| blk: {
+            var s: usize = 5;
+            for (map) |entry| s += 4 + entry.key.len + serializedValueSize(entry.value);
+            break :blk s;
+        },
+    };
+}
 
 /// Serialize node data to bytes
 fn serializeNode(labels: []const SymbolId, properties: []const Property, buf: []u8) ![]u8 {
@@ -461,6 +513,11 @@ fn mapBTreeError(err: BTreeError) NodeError {
     return switch (err) {
         BTreeError.KeyNotFound => NodeError.NotFound,
         BTreeError.OutOfMemory => NodeError.OutOfMemory,
+        // PageFull from the leaf layer surfaces when a single node's
+        // serialized payload would not fit inside one btree leaf page.
+        // Translate it into BufferTooSmall so callers see a clear "value
+        // too large for page_size" signal instead of a generic BTreeError.
+        BTreeError.PageFull => NodeError.BufferTooSmall,
         else => NodeError.BTreeError,
     };
 }

--- a/src/storage/btree.zig
+++ b/src/storage/btree.zig
@@ -480,9 +480,22 @@ pub const BTree = struct {
             return BTreeError.DuplicateKey;
         }
 
-        // Calculate space needed: slot(2) + key_len(2) + val_len(2) + key + value
-        const entry_size: u16 = @intCast(4 + key.len + value.len);
-        const space_needed: u16 = LEAF_SLOT_SIZE + entry_size;
+        // Calculate space needed: slot(2) + key_len(2) + val_len(2) + key + value.
+        // Use usize for the math so comically large values do not wrap u16
+        // before we compare against the per-page upper bound; a key/value
+        // pair that cannot physically fit in an empty page is rejected
+        // with `PageFull` instead of panicking inside `insertLeafEntry`.
+        const entry_size_usize: usize = 4 + key.len + value.len;
+        const space_needed_usize: usize = LEAF_SLOT_SIZE + entry_size_usize;
+        const max_leaf_entry = maxLeafEntrySize(self.page_size);
+        if (entry_size_usize > max_leaf_entry) {
+            self.bp.unpinPage(frame, false);
+            return BTreeError.PageFull;
+        }
+
+        const entry_size: u16 = @intCast(entry_size_usize);
+        _ = entry_size;
+        const space_needed: u16 = @intCast(space_needed_usize);
         const free_space = LeafNode.getFreeSpace(buf, self.page_size);
 
         if (free_space >= space_needed) {
@@ -494,6 +507,25 @@ pub const BTree = struct {
 
         // Need to split
         return self.splitLeafAndInsert(frame, search.slot, key, value);
+    }
+
+    /// Maximum (key_len + value_len + per-entry framing) that a leaf page
+    /// can hold. An entry larger than this cannot fit even into a freshly
+    /// initialized leaf, so it must be rejected up-front. Per-entry
+    /// framing = key_len(2) + val_len(2) = 4 bytes, already included here.
+    fn maxLeafEntrySize(page_size: u32) usize {
+        const reserved = @sizeOf(PageHeader) + LEAF_HEADER_SIZE + LEAF_SLOT_SIZE;
+        if (page_size <= reserved) return 0;
+        return @as(usize, page_size) - reserved;
+    }
+
+    /// Check whether a (key, value) pair could theoretically fit into a
+    /// single empty leaf page of the tree. Callers perform this before a
+    /// delete+insert sequence so they can bail out with a clean error
+    /// instead of leaving the tree missing an entry.
+    pub fn canFitLeafEntry(self: *const Self, key: []const u8, value_len: usize) bool {
+        const entry_size: usize = 4 + key.len + value_len;
+        return entry_size <= maxLeafEntrySize(self.page_size);
     }
 
     fn insertLeafEntry(self: *Self, buf: []u8, slot: u16, key: []const u8, value: []const u8) void {

--- a/src/storage/database.zig
+++ b/src/storage/database.zig
@@ -124,6 +124,10 @@ pub const DatabaseError = error{
     TransactionNotActive,
     TransactionReadOnly,
     TransactionsNotEnabled,
+    /// Serialized node/edge payload is too large for a single btree leaf
+    /// page. The caller should split the value across multiple entries
+    /// or open the database with a larger `page_size`.
+    ValueTooLarge,
 };
 
 /// Query execution errors
@@ -1278,6 +1282,20 @@ pub const Database = struct {
     // Graph Operations - Nodes
     // ========================================================================
 
+    /// Translate node-store errors into the user-facing DatabaseError set.
+    /// Reserved for call sites that want the `BufferTooSmall → ValueTooLarge`
+    /// translation; internal recovery paths may still use `catch {}`.
+    fn mapNodeStoreError(err: node_mod.NodeError) DatabaseError {
+        return switch (err) {
+            node_mod.NodeError.NotFound => DatabaseError.NotFound,
+            node_mod.NodeError.AlreadyExists => DatabaseError.AlreadyExists,
+            node_mod.NodeError.OutOfMemory => DatabaseError.OutOfMemory,
+            node_mod.NodeError.BufferPoolFull => DatabaseError.BufferPoolFull,
+            node_mod.NodeError.BufferTooSmall => DatabaseError.ValueTooLarge,
+            else => DatabaseError.IoError,
+        };
+    }
+
     /// Create a new node with the given labels
     /// Returns the new node's ID
     /// If txn is null, the operation is auto-committed
@@ -1303,8 +1321,8 @@ pub const Database = struct {
         }
 
         // Create node with no properties (can be added later with setNodeProperty)
-        const node_id = self.node_store.create(label_ids, &[_]node_mod.Property{}) catch {
-            return DatabaseError.IoError;
+        const node_id = self.node_store.create(label_ids, &[_]node_mod.Property{}) catch |err| {
+            return mapNodeStoreError(err);
         };
 
         // Update label index
@@ -1382,11 +1400,20 @@ pub const Database = struct {
                     };
                     defer self.allocator.free(prop_bytes);
 
-                    var buf: [4096]u8 = undefined;
-                    // Serialize node data for WAL and undo (now with properties)
-                    const payload = wal_payload.serializeNodeDelete(&buf, node_id, node.labels, prop_bytes) catch {
-                        return DatabaseError.IoError;
-                    };
+                    // Sized from wal_payload.nodeDeleteSize so a node with
+                    // large property blobs serializes into an exact-fit
+                    // buffer rather than hitting the old 4 KiB stack cap.
+                    const payload_buf = self.allocator.alloc(
+                        u8,
+                        wal_payload.nodeDeleteSize(node.labels.len, prop_bytes.len),
+                    ) catch return DatabaseError.OutOfMemory;
+                    defer self.allocator.free(payload_buf);
+                    const payload = wal_payload.serializeNodeDelete(
+                        payload_buf,
+                        node_id,
+                        node.labels,
+                        prop_bytes,
+                    ) catch return DatabaseError.IoError;
                     _ = tm.logOperation(t, .delete, payload) catch {
                         return DatabaseError.IoError;
                     };
@@ -1490,48 +1517,62 @@ pub const Database = struct {
         }
 
         // Update the node
-        self.node_store.update(node_id, existing_node.labels, new_props.items) catch {
-            return DatabaseError.IoError;
+        self.node_store.update(node_id, existing_node.labels, new_props.items) catch |err| {
+            return mapNodeStoreError(err);
         };
 
-        // Log to WAL and add undo entry if transaction is provided
+        // Log to WAL and add undo entry if transaction is provided.
+        // Every buffer below is sized from `wal_payload.*Size` helpers and
+        // heap-allocated so STRING/BYTES property values of arbitrary
+        // length round-trip through the write-ahead log. The previous
+        // fixed [512]u8 / [2048]u8 stack buffers capped values at ~507
+        // bytes and composite payloads at ~2 KiB.
         if (txn) |t| {
             if (self.txn_manager) |*tm| {
-                // Serialize old value for undo (if it existed)
-                var old_value_bytes: ?[]u8 = null;
-                var owns_old_bytes = false;
-                if (old_value) |ov| {
-                    var old_buf: [512]u8 = undefined;
-                    const old_size = wal_payload.serializePropertyValueToBuf(&old_buf, ov) catch null;
-                    if (old_size) |sz| {
-                        old_value_bytes = self.allocator.dupe(u8, old_buf[0..sz]) catch null;
-                        owns_old_bytes = old_value_bytes != null;
-                    }
-                }
-                defer if (owns_old_bytes) self.allocator.free(old_value_bytes.?);
+                const old_value_bytes = try self.serializePropertyValueAlloc(old_value);
+                defer if (old_value_bytes) |b| self.allocator.free(b);
 
-                // Serialize new value
-                var new_buf: [512]u8 = undefined;
-                const new_size = wal_payload.serializePropertyValueToBuf(&new_buf, value) catch {
-                    return DatabaseError.IoError;
-                };
+                const new_value_bytes = try self.serializePropertyValueAlloc(value) orelse unreachable;
+                defer self.allocator.free(new_value_bytes);
 
-                var buf: [2048]u8 = undefined;
-                // Serialize property update for WAL (now with old value)
-                const payload = wal_payload.serializePropertyUpdate(&buf, node_id, key, old_value_bytes, new_buf[0..new_size]) catch {
-                    return DatabaseError.IoError;
-                };
+                const old_len = if (old_value_bytes) |b| b.len else 0;
+                const payload_buf = self.allocator.alloc(
+                    u8,
+                    wal_payload.propertyUpdateSize(key.len, old_len, new_value_bytes.len),
+                ) catch return DatabaseError.OutOfMemory;
+                defer self.allocator.free(payload_buf);
+                const payload = wal_payload.serializePropertyUpdate(
+                    payload_buf,
+                    node_id,
+                    key,
+                    old_value_bytes,
+                    new_value_bytes,
+                ) catch return DatabaseError.IoError;
+
                 _ = tm.logOperation(t, .update, payload) catch {
                     return DatabaseError.IoError;
                 };
-                // Undo of update: store payload containing old value
-                // For new properties (found=false), undo is delete; for existing, restore old value
+                // Undo of update: store payload containing old value.
+                // For new properties (found=false), undo is delete; for existing, restore old value.
                 const undo_op: UndoOpType = if (found) .update else .insert;
                 tm.addUndoEntry(t, undo_op, .property, node_id, 0, key_id, payload) catch {
                     return DatabaseError.IoError;
                 };
             }
         }
+    }
+
+    /// Heap-allocate and serialize a PropertyValue into a fresh WAL-format
+    /// byte slice. Returns null when `value` is null. Caller owns the
+    /// returned memory and must free it.
+    fn serializePropertyValueAlloc(self: *Self, value: ?PropertyValue) !?[]u8 {
+        const v = value orelse return null;
+        const size = wal_payload.propertyValueSize(v);
+        const buf = self.allocator.alloc(u8, size) catch return DatabaseError.OutOfMemory;
+        errdefer self.allocator.free(buf);
+        const written = wal_payload.serializePropertyValueToBuf(buf, v) catch return DatabaseError.IoError;
+        if (written != size) return DatabaseError.IoError;
+        return buf;
     }
 
     /// Remove a property from a node.
@@ -1585,31 +1626,34 @@ pub const Database = struct {
         }
 
         // Update the node
-        self.node_store.update(node_id, existing_node.labels, new_props.items) catch {
-            return DatabaseError.IoError;
+        self.node_store.update(node_id, existing_node.labels, new_props.items) catch |err| {
+            return mapNodeStoreError(err);
         };
 
-        // Log to WAL and add undo entry if transaction is provided
+        // Log to WAL and add undo entry if transaction is provided.
+        // Buffer sizes come from `wal_payload.*Size` helpers so arbitrarily
+        // large old-value payloads fit (previously capped by [512]u8 and
+        // [2048]u8 stack buffers at ~507 B and ~2 KiB respectively).
         if (txn) |t| {
             if (self.txn_manager) |*tm| {
-                // Serialize old value for undo
-                var old_value_bytes: ?[]u8 = null;
-                var owns_old_bytes = false;
-                if (old_value) |ov| {
-                    var old_buf: [512]u8 = undefined;
-                    const old_size = wal_payload.serializePropertyValueToBuf(&old_buf, ov) catch null;
-                    if (old_size) |sz| {
-                        old_value_bytes = self.allocator.dupe(u8, old_buf[0..sz]) catch null;
-                        owns_old_bytes = old_value_bytes != null;
-                    }
-                }
-                defer if (owns_old_bytes) self.allocator.free(old_value_bytes.?);
+                const old_value_bytes = try self.serializePropertyValueAlloc(old_value);
+                defer if (old_value_bytes) |b| self.allocator.free(b);
 
-                var buf: [2048]u8 = undefined;
+                const old_len = if (old_value_bytes) |b| b.len else 0;
+                const payload_buf = self.allocator.alloc(
+                    u8,
+                    wal_payload.propertyUpdateSize(key.len, old_len, 0),
+                ) catch return DatabaseError.OutOfMemory;
+                defer self.allocator.free(payload_buf);
                 // Serialize property delete for WAL (old value, no new value)
-                const payload = wal_payload.serializePropertyUpdate(&buf, node_id, key, old_value_bytes, &[_]u8{}) catch {
-                    return DatabaseError.IoError;
-                };
+                const payload = wal_payload.serializePropertyUpdate(
+                    payload_buf,
+                    node_id,
+                    key,
+                    old_value_bytes,
+                    &[_]u8{},
+                ) catch return DatabaseError.IoError;
+
                 _ = tm.logOperation(t, .delete, payload) catch {
                     return DatabaseError.IoError;
                 };
@@ -2015,13 +2059,23 @@ pub const Database = struct {
             return DatabaseError.IoError;
         };
 
-        // Log to WAL and add undo entry if transaction is provided
+        // Log to WAL and add undo entry if transaction is provided.
+        // Buffer sized via edgeInsertSize so arbitrarily long edge_type
+        // names survive (previously capped at ~240 bytes by [256]u8).
         if (txn) |t| {
             if (self.txn_manager) |*tm| {
-                var buf: [256]u8 = undefined;
-                const payload = wal_payload.serializeEdgeInsert(&buf, edge_id, source, target, edge_type) catch {
-                    return DatabaseError.IoError;
-                };
+                const payload_buf = self.allocator.alloc(
+                    u8,
+                    wal_payload.edgeInsertSize(edge_type),
+                ) catch return DatabaseError.OutOfMemory;
+                defer self.allocator.free(payload_buf);
+                const payload = wal_payload.serializeEdgeInsert(
+                    payload_buf,
+                    edge_id,
+                    source,
+                    target,
+                    edge_type,
+                ) catch return DatabaseError.IoError;
                 _ = tm.logOperation(t, .insert, payload) catch {
                     return DatabaseError.IoError;
                 };
@@ -2093,17 +2147,19 @@ pub const Database = struct {
                 }
                 defer if (owns_prop_bytes) self.allocator.free(prop_bytes);
 
-                var buf: [2048]u8 = undefined;
+                const payload_buf = self.allocator.alloc(
+                    u8,
+                    wal_payload.edgeDeleteSize(prop_bytes.len),
+                ) catch return DatabaseError.OutOfMemory;
+                defer self.allocator.free(payload_buf);
                 const payload = wal_payload.serializeEdgeDelete(
-                    &buf,
+                    payload_buf,
                     edge_id,
                     source,
                     target,
                     type_id,
                     prop_bytes,
-                ) catch {
-                    return DatabaseError.IoError;
-                };
+                ) catch return DatabaseError.IoError;
                 _ = tm.logOperation(t, .delete, payload) catch {
                     return DatabaseError.IoError;
                 };
@@ -2158,9 +2214,13 @@ pub const Database = struct {
                 }
                 defer if (owns_prop_bytes) self.allocator.free(prop_bytes);
 
-                var buf: [2048]u8 = undefined;
+                const payload_buf = self.allocator.alloc(
+                    u8,
+                    wal_payload.edgeDeleteSize(prop_bytes.len),
+                ) catch return DatabaseError.OutOfMemory;
+                defer self.allocator.free(payload_buf);
                 const payload = wal_payload.serializeEdgeDelete(
-                    &buf,
+                    payload_buf,
                     edge.id,
                     edge.source,
                     edge.target,
@@ -2226,17 +2286,8 @@ pub const Database = struct {
 
         if (txn) |t| {
             if (self.txn_manager) |*tm| {
-                var old_value_bytes: ?[]u8 = null;
-                var owns_old_value_bytes = false;
-                if (old_value) |ov| {
-                    var old_value_buf: [512]u8 = undefined;
-                    const old_value_size = wal_payload.serializePropertyValueToBuf(&old_value_buf, ov) catch null;
-                    if (old_value_size) |sz| {
-                        old_value_bytes = self.allocator.dupe(u8, old_value_buf[0..sz]) catch null;
-                        owns_old_value_bytes = old_value_bytes != null;
-                    }
-                }
-                defer if (owns_old_value_bytes) self.allocator.free(old_value_bytes.?);
+                const old_value_bytes = try self.serializePropertyValueAlloc(old_value);
+                defer if (old_value_bytes) |b| self.allocator.free(b);
 
                 var old_prop_bytes: []u8 = &[_]u8{};
                 var owns_old_prop_bytes = false;
@@ -2246,9 +2297,13 @@ pub const Database = struct {
                 }
                 defer if (owns_old_prop_bytes) self.allocator.free(old_prop_bytes);
 
-                var old_buf: [4096]u8 = undefined;
+                const old_payload_buf = self.allocator.alloc(
+                    u8,
+                    wal_payload.edgeDeleteSize(old_prop_bytes.len),
+                ) catch return DatabaseError.OutOfMemory;
+                defer self.allocator.free(old_payload_buf);
                 const old_payload = wal_payload.serializeEdgeDelete(
-                    &old_buf,
+                    old_payload_buf,
                     edge.id,
                     edge.source,
                     edge.target,
@@ -2256,18 +2311,21 @@ pub const Database = struct {
                     old_prop_bytes,
                 ) catch return DatabaseError.IoError;
 
-                var value_buf: [512]u8 = undefined;
-                const value_size = wal_payload.serializePropertyValueToBuf(&value_buf, value) catch {
-                    return DatabaseError.IoError;
-                };
+                const new_value_bytes = try self.serializePropertyValueAlloc(value) orelse unreachable;
+                defer self.allocator.free(new_value_bytes);
 
-                var wal_buf: [2048]u8 = undefined;
+                const old_len = if (old_value_bytes) |b| b.len else 0;
+                const wal_payload_buf = self.allocator.alloc(
+                    u8,
+                    wal_payload.edgePropertyUpdateSize(key.len, old_len, new_value_bytes.len),
+                ) catch return DatabaseError.OutOfMemory;
+                defer self.allocator.free(wal_payload_buf);
                 const wal_payload_bytes = wal_payload.serializeEdgePropertyUpdate(
-                    &wal_buf,
+                    wal_payload_buf,
                     edge.id,
                     key,
                     old_value_bytes,
-                    value_buf[0..value_size],
+                    new_value_bytes,
                 ) catch return DatabaseError.IoError;
 
                 _ = tm.logOperation(t, .update, wal_payload_bytes) catch return DatabaseError.IoError;
@@ -2326,17 +2384,8 @@ pub const Database = struct {
 
         if (txn) |t| {
             if (self.txn_manager) |*tm| {
-                var old_value_bytes: ?[]u8 = null;
-                var owns_old_value_bytes = false;
-                if (old_value) |ov| {
-                    var old_value_buf: [512]u8 = undefined;
-                    const old_value_size = wal_payload.serializePropertyValueToBuf(&old_value_buf, ov) catch null;
-                    if (old_value_size) |sz| {
-                        old_value_bytes = self.allocator.dupe(u8, old_value_buf[0..sz]) catch null;
-                        owns_old_value_bytes = old_value_bytes != null;
-                    }
-                }
-                defer if (owns_old_value_bytes) self.allocator.free(old_value_bytes.?);
+                const old_value_bytes = try self.serializePropertyValueAlloc(old_value);
+                defer if (old_value_bytes) |b| self.allocator.free(b);
 
                 var old_prop_bytes: []u8 = &[_]u8{};
                 var owns_old_prop_bytes = false;
@@ -2346,9 +2395,13 @@ pub const Database = struct {
                 }
                 defer if (owns_old_prop_bytes) self.allocator.free(old_prop_bytes);
 
-                var old_buf: [4096]u8 = undefined;
+                const old_payload_buf = self.allocator.alloc(
+                    u8,
+                    wal_payload.edgeDeleteSize(old_prop_bytes.len),
+                ) catch return DatabaseError.OutOfMemory;
+                defer self.allocator.free(old_payload_buf);
                 const old_payload = wal_payload.serializeEdgeDelete(
-                    &old_buf,
+                    old_payload_buf,
                     edge.id,
                     edge.source,
                     edge.target,
@@ -2356,9 +2409,14 @@ pub const Database = struct {
                     old_prop_bytes,
                 ) catch return DatabaseError.IoError;
 
-                var wal_buf: [2048]u8 = undefined;
+                const old_len = if (old_value_bytes) |b| b.len else 0;
+                const wal_payload_buf = self.allocator.alloc(
+                    u8,
+                    wal_payload.edgePropertyUpdateSize(key.len, old_len, 0),
+                ) catch return DatabaseError.OutOfMemory;
+                defer self.allocator.free(wal_payload_buf);
                 const wal_payload_bytes = wal_payload.serializeEdgePropertyUpdate(
-                    &wal_buf,
+                    wal_payload_buf,
                     edge.id,
                     key,
                     old_value_bytes,
@@ -3436,6 +3494,200 @@ test "graph crud operations" {
     try db.deleteNode(null, alice);
     try std.testing.expect(!(try db.nodeExists(alice)));
     try std.testing.expect(try db.nodeExists(bob));
+}
+
+test "setNodeProperty round-trips string values above the old 512-byte WAL buffer" {
+    // Regression: `setNodeProperty` used to serialize the new/old values
+    // into fixed `[512]u8` stack buffers and the outer WAL payload into a
+    // `[2048]u8` buffer, which capped STRING/BYTES properties at ~507
+    // bytes and composite payloads at ~2 KiB. Both fixed buffers are
+    // now heap-allocated from `wal_payload.*Size`, so values round-trip
+    // through the node store and WAL undo path up to the btree page-size
+    // ceiling (a separate limitation tracked in `btree.zig`).
+    const allocator = std.testing.allocator;
+    const path = "/tmp/lattice_large_prop_test.ltdb";
+
+    var db = try Database.open(allocator, path, .{
+        .create = true,
+        .config = .{
+            .enable_wal = true,
+            .enable_fts = false,
+        },
+    });
+    defer {
+        db.close();
+        std.fs.cwd().deleteFile(path) catch {};
+        std.fs.cwd().deleteFile("/tmp/lattice_large_prop_test.ltdb.wal") catch {};
+    }
+
+    const node_id = try db.createNode(null, &[_][]const u8{"Doc"});
+
+    // Walk past the old 512 B per-property cap and the 2 KiB composite
+    // WAL-payload cap. 3000 B is comfortably below the 4 KiB btree page
+    // size so entries still fit in a single leaf slot.
+    const sizes = [_]usize{ 64, 512, 600, 1024, 2048, 3000 };
+    var buf: [3000]u8 = undefined;
+    for (sizes, 0..) |sz, i| {
+        // Distinct byte pattern per offset so ordering regressions fail loud.
+        for (buf[0..sz], 0..) |*b, j| b.* = @truncate(j +% (i * 17));
+        try db.setNodeProperty(null, node_id, "content", .{ .string_val = buf[0..sz] });
+
+        var got = (try db.getNodeProperty(node_id, "content")).?;
+        defer got.deinit(allocator);
+        try std.testing.expectEqualSlices(u8, buf[0..sz], got.string_val);
+    }
+}
+
+test "getNodesByLabel returns every node with the requested label for reopen indexing" {
+    // Regression: nullclaw's LatticeMemory adapter needs to rebuild its
+    // in-memory key→node index on database reopen so short-lived CLI
+    // invocations don't silently create duplicate Entry nodes. It walks
+    // every node labelled "Entry" (plus "Category", "Session", etc.)
+    // via getNodesByLabel, so the API has to return all matches even
+    // when they were created in earlier process lifetimes.
+    const allocator = std.testing.allocator;
+    const path = "/tmp/lattice_nodes_by_label_reopen_test.ltdb";
+
+    {
+        var db = try Database.open(allocator, path, .{
+            .create = true,
+            .config = .{ .enable_wal = true, .enable_fts = false },
+        });
+        defer {
+            db.close();
+        }
+
+        const ids = [_]NodeId{
+            try db.createNode(null, &[_][]const u8{"Entry"}),
+            try db.createNode(null, &[_][]const u8{"Entry"}),
+            try db.createNode(null, &[_][]const u8{"Entry"}),
+        };
+        _ = ids;
+        // Create an unrelated Category node so the label filter has to
+        // actually discriminate, not just return every node in the store.
+        _ = try db.createNode(null, &[_][]const u8{"Category"});
+    }
+
+    // Reopen the database in a fresh process-equivalent scope. If
+    // getNodesByLabel only surfaced nodes from the *current* process
+    // the count would be 0 and this test would fail.
+    var db = try Database.open(allocator, path, .{
+        .create = false,
+        .config = .{ .enable_wal = true, .enable_fts = false },
+    });
+    defer {
+        db.close();
+        std.fs.cwd().deleteFile(path) catch {};
+        std.fs.cwd().deleteFile("/tmp/lattice_nodes_by_label_reopen_test.ltdb.wal") catch {};
+    }
+
+    const entries = try db.getNodesByLabel("Entry");
+    defer allocator.free(entries);
+    try std.testing.expectEqual(@as(usize, 3), entries.len);
+
+    const cats = try db.getNodesByLabel("Category");
+    defer allocator.free(cats);
+    try std.testing.expectEqual(@as(usize, 1), cats.len);
+
+    // Unknown labels surface as an empty slice, not an error.
+    const missing = try db.getNodesByLabel("Nonexistent");
+    defer allocator.free(missing);
+    try std.testing.expectEqual(@as(usize, 0), missing.len);
+}
+
+test "ftsIndexDocument handles multi-KiB markdown-shaped documents" {
+    // Regression: `nullclaw onboard --memory latticedb` tripped a
+    // `panic: integer overflow` inside `lattice_fts_index` when it
+    // reached AGENTS.md (9242 bytes). Reproduce the exact shape of the
+    // failing flow — Database open with fts enabled, a sequence of
+    // stores ranging from ~1 KiB to ~9 KiB of realistic markdown
+    // tokens — and assert each call returns cleanly.
+    const allocator = std.testing.allocator;
+    const path = "/tmp/lattice_fts_db_large_test.ltdb";
+
+    var db = try Database.open(allocator, path, .{
+        .create = true,
+        .config = .{
+            .enable_wal = true,
+            .enable_fts = true,
+        },
+    });
+    defer {
+        db.close();
+        std.fs.cwd().deleteFile(path) catch {};
+        std.fs.cwd().deleteFile("/tmp/lattice_fts_db_large_test.ltdb.wal") catch {};
+    }
+
+    // Scaffold a family of varied documents that together exercise the
+    // per-call and cumulative FTS code paths. Vocabulary grows with
+    // the doc index so posting lists keep extending.
+    const sizes = [_]usize{ 1674, 9242, 861, 2112, 637, 478, 169, 1591 };
+
+    var buf: [32768]u8 = undefined;
+    var rng = std.Random.DefaultPrng.init(0x1abe1);
+    const r = rng.random();
+
+    for (sizes, 0..) |target, idx| {
+        var pos: usize = 0;
+        while (pos < target) {
+            // Emit pseudo-markdown tokens: short punctuation-free words,
+            // the occasional '#' heading marker, newlines. Vocab keeps
+            // shifting with idx so later docs keep extending dictionary.
+            var word_buf: [32]u8 = undefined;
+            const wlen: usize = 3 + (r.int(usize) % 10);
+            var j: usize = 0;
+            while (j < wlen and pos < target) : (j += 1) {
+                word_buf[j] = 'a' + @as(u8, @intCast((idx + j + r.int(usize)) % 26));
+            }
+            const remaining = target - pos;
+            const take = @min(j, remaining);
+            @memcpy(buf[pos..][0..take], word_buf[0..take]);
+            pos += take;
+            if (pos < target) {
+                buf[pos] = ' ';
+                pos += 1;
+            }
+        }
+
+        const node_id = try db.createNode(null, &[_][]const u8{"Entry"});
+        try db.ftsIndexDocument(node_id, buf[0..target]);
+    }
+}
+
+test "setNodeProperty rejects values larger than one btree leaf page gracefully" {
+    // Regression: a property value big enough that its serialized node
+    // cannot fit in a single btree leaf used to panic deep inside
+    // `insertLeafEntry` (`min_offset - entry_size` integer overflow).
+    // It now propagates as `DatabaseError.ValueTooLarge` so callers can
+    // split the value or widen `page_size` instead of crashing.
+    const allocator = std.testing.allocator;
+    const path = "/tmp/lattice_oversized_value_test.ltdb";
+
+    var db = try Database.open(allocator, path, .{
+        .create = true,
+        .config = .{
+            .enable_wal = false,
+            .enable_fts = false,
+        },
+    });
+    defer {
+        db.close();
+        std.fs.cwd().deleteFile(path) catch {};
+    }
+
+    const node_id = try db.createNode(null, &[_][]const u8{"Doc"});
+
+    // ~16 KiB blows past the 4 KiB default page_size by several pages.
+    var big_buf: [16384]u8 = undefined;
+    @memset(&big_buf, 'x');
+    const result = db.setNodeProperty(null, node_id, "blob", .{ .string_val = &big_buf });
+    try std.testing.expectError(DatabaseError.ValueTooLarge, result);
+
+    // Prior (fitting) state must survive the rejected write.
+    try db.setNodeProperty(null, node_id, "blob", .{ .string_val = "small" });
+    var got = (try db.getNodeProperty(node_id, "blob")).?;
+    defer got.deinit(allocator);
+    try std.testing.expectEqualStrings("small", got.string_val);
 }
 
 test "query: simple MATCH RETURN" {

--- a/src/transaction/wal_payload.zig
+++ b/src/transaction/wal_payload.zig
@@ -561,6 +561,49 @@ pub fn deserializeLabelRemove(payload: []const u8) PayloadError!LabelMutationPay
 }
 
 // ============================================================================
+// Payload Size Calculators
+// ============================================================================
+//
+// Callers (storage/database.zig and friends) used to serialize WAL payloads
+// into fixed-size stack buffers like `var buf: [512]u8 = undefined;`, which
+// imposed a ~507-byte cap on STRING/BYTES property values and a ~2 KiB cap
+// on composite node/edge payloads. These helpers return the exact byte
+// count each `serialize*` function will emit so callers can heap-allocate
+// an exact-fit buffer and pass it in.
+
+/// Required byte count for `serializeNodeInsert(buf, node_id, labels)`.
+pub fn nodeInsertSize(labels: []const []const u8) usize {
+    var size: usize = 1 + 8 + 2; // tag + node_id + label_count
+    for (labels) |label| size += 2 + label.len;
+    return size;
+}
+
+/// Required byte count for `serializeNodeDelete(buf, node_id, label_ids, properties)`.
+pub fn nodeDeleteSize(label_count: usize, properties_len: usize) usize {
+    return 1 + 8 + 2 + label_count * 2 + 4 + properties_len;
+}
+
+/// Required byte count for `serializeEdgeInsert(buf, edge_id, source, target, edge_type)`.
+pub fn edgeInsertSize(edge_type: []const u8) usize {
+    return 1 + 8 + 8 + 8 + 2 + edge_type.len;
+}
+
+/// Required byte count for `serializeEdgeDelete(buf, edge_id, source, target, type_id, properties)`.
+pub fn edgeDeleteSize(properties_len: usize) usize {
+    return 1 + 8 + 8 + 8 + 2 + 4 + properties_len;
+}
+
+/// Required byte count for `serializePropertyUpdate(buf, node_id, key, old_value, new_value)`.
+pub fn propertyUpdateSize(key_len: usize, old_len: usize, new_len: usize) usize {
+    return 1 + 8 + 2 + key_len + 4 + old_len + 4 + new_len;
+}
+
+/// Required byte count for `serializeEdgePropertyUpdate(buf, edge_id, key, old_value, new_value)`.
+pub fn edgePropertyUpdateSize(key_len: usize, old_len: usize, new_len: usize) usize {
+    return 1 + 8 + 2 + key_len + 4 + old_len + 4 + new_len;
+}
+
+// ============================================================================
 // Property Serialization for Undo
 // ============================================================================
 
@@ -636,7 +679,7 @@ pub fn deserializePropertyValueFromBytes(allocator: Allocator, data: []const u8)
 }
 
 /// Calculate size needed for a PropertyValue.
-fn propertyValueSize(value: PropertyValue) usize {
+pub fn propertyValueSize(value: PropertyValue) usize {
     return switch (value) {
         .null_val => 1,
         .bool_val => 2,

--- a/tests/unit/search_test.zig
+++ b/tests/unit/search_test.zig
@@ -660,6 +660,49 @@ test "fts: indexing thousands of repeated terms remains responsive" {
     try std.testing.expectEqual(@as(u64, 3000), stats.total_docs);
 }
 
+test "fts: reindex oversized document purges stale terms via dictionary scan" {
+    const allocator = std.testing.allocator;
+    var db = try helpers.TempDb.initWithPoolSize(allocator, "fts_reindex_oversize", 1024 * 1024);
+    defer db.deinit();
+
+    var dict_tree = try BTree.init(allocator, db.bp);
+    var lengths_tree = try BTree.init(allocator, db.bp);
+    var reverse_tree = try BTree.init(allocator, db.bp);
+
+    var index = FtsIndex.init(allocator, db.bp, &dict_tree, &lengths_tree, &reverse_tree, .{});
+
+    // Build a document whose unique-term list is larger than a single btree
+    // leaf page, forcing indexDocument to skip populating the reverse index.
+    // removeDocument must then fall back to a full dictionary scan; otherwise
+    // the old terms survive re-indexing under the same doc_id.
+    var big: std.ArrayList(u8) = .empty;
+    defer big.deinit(allocator);
+    var i: usize = 0;
+    while (i < 1200) : (i += 1) {
+        try big.writer(allocator).print("alphaunique{d} ", .{i});
+    }
+
+    _ = try index.indexDocument(42, big.items);
+
+    // Sanity: a term from the oversized doc is queryable via forward posting.
+    const pre = try index.search("alphaunique7", 10);
+    defer index.freeResults(pre);
+    try std.testing.expectEqual(@as(usize, 1), pre.len);
+
+    // Remove + reindex with different content. The fallback path must evict
+    // the old posting entries so stale terms no longer match.
+    try index.removeDocument(42);
+    _ = try index.indexDocument(42, "fresh content betaword");
+
+    const stale = try index.search("alphaunique7", 10);
+    defer index.freeResults(stale);
+    try std.testing.expectEqual(@as(usize, 0), stale.len);
+
+    const fresh = try index.search("betaword", 10);
+    defer index.freeResults(fresh);
+    try std.testing.expectEqual(@as(usize, 1), fresh.len);
+}
+
 test "fts: reindex same document updates content" {
     const allocator = std.testing.allocator;
     var db = try helpers.TempDb.init(allocator, "fts_reindex");


### PR DESCRIPTION
## Summary

Primary change: exposes `lattice` as a public Zig module via `b.addModule("lattice", ...)`, so sibling Zig packages can consume the library as a pure Zig dependency (`b.dependency("latticedb", .{}).module("lattice")`) instead of going through the C ABI. The static/shared library and CLI artifacts are unchanged.

This PR also bundles several fixes that surfaced while onboarding nullclaw against the newly-exposed module — keeping them together makes the module usable end-to-end.

## What's in this PR

### B-tree oversize error handling
- `storage/btree.zig`: `insertLeafEntry` no longer panics on u16 underflow when a value is larger than the leaf page can fit; short-circuits to `BTreeError.PageFull` which bubbles up as `ValueTooLarge` → C API `err_full`.
- Node-store update path calls `canFitLeafEntry` before delete+insert so an oversized update leaves the previous node intact.

### Node / WAL serialization strategy
- Lifts fixed-size `[512]u8` / `[2048]u8` / `[4096]u8` stack buffers in `storage/database.zig` (`setNodeProperty`, `removeNodeProperty`, `setEdgePropertyById`, `removeEdgePropertyById`) and `graph/node.zig` (`create`/`createWithId`/`update`) to heap allocations sized from new `wal_payload.*Size` / `graph/node.serializedNodeSize` helpers.
- Result: WAL logging and node updates scale with caller data rather than with magic stack-buffer sizes. Previously, any STRING/BYTES property >~507 bytes or any node with >4 KiB serialized form returned `err_io` / `BufferTooSmall`.

### FTS reverse-index behavior
- `reverse_index.setDocTerms` calls `canFitLeafEntry` up front and returns the new `ReverseIndexError.ValueTooLarge` instead of tearing down and re-failing on insert.
- `fts.indexDocument` treats `ValueTooLarge` as a non-fatal warning: forward postings, doc lengths, and scorer entries are still written, so the document stays queryable.
- **`fts.removeDocument` now has a dictionary-scan fallback** for the oversized-doc case. Without it, remove+reindex under the same `doc_id` left stale posting entries alive and the old terms resurrected on the next query. The fallback snapshots `(term, posting_page)` pairs first to avoid mutating the dictionary tree mid-iteration, then removes each entry and adjusts dictionary statistics.

### Public Zig module exposure
- `build.zig`: `b.createModule` → `b.addModule("lattice", ...)`. The existing self-import `lib_module.addImport("lattice", lib_module)` continues to work.

### New C API: `lattice_get_nodes_by_label`
- `lattice_get_nodes_by_label(db, label, label_len, ids_out, count_out)` with a paired `lattice_free_node_ids` deallocator wraps `Database.getNodesByLabel`.
- Motivating use case: a label-indexed adapter (nullclaw `LatticeMemory`) can replay all existing `Entry`/`Category`/`Session` nodes into its in-memory cache on init instead of starting empty and silently creating duplicates on subsequent writes.
- Exposed through **all three** language bindings:
  - Python (`bindings/python`): `Database.get_nodes_by_label()`.
  - TypeScript (`bindings/typescript`): `Database.getNodesByLabel()`.
  - Go (`bindings/go`): `DB.GetNodesByLabel() ([]NodeID, error)`.

## Test plan

- [x] `zig build test` — all existing tests pass; 679 passed, 5 skipped.
- [x] New regression: `fts: reindex oversized document purges stale terms via dictionary scan` — builds a >1 leaf-page term list, removes + re-indexes under the same `doc_id`, asserts the old term no longer matches and the new term does.
- [x] New regression: `getNodesByLabel returns every node with the requested label for reopen indexing` — creates Entry/Category nodes, closes+reopens the DB, asserts the label lookup still surfaces every entry.
- [x] New regression: two round-trip tests in `storage/database.zig` cover property values up to 3000 bytes and assert that truly oversized values return `ValueTooLarge` without disturbing prior state.
- [x] New regression: `ftsIndexDocument handles multi-KiB markdown-shaped documents` exercises the exact size series nullclaw's onboard writes (SOUL / AGENTS / TOOLS / CONFIG / IDENTITY / USER / HEARTBEAT / BOOTSTRAP).
- [x] TypeScript: `npx tsc --noEmit` clean.
- [x] Go: `go build -tags repolocal ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)