### PR TITLE
feat(bindings): add Java JNI bindings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,6 +189,39 @@ jobs:
         run: go test -tags repolocal ./...
 
   # ============================================
+  # Java tests
+  # ============================================
+  java-test:
+    name: Java Tests
+    needs: zig-build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-14]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download shared library
+        uses: actions/download-artifact@v4
+        with:
+          name: shared-lib-${{ matrix.os }}
+          path: zig-out/lib
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+          cache-dependency-path: bindings/java/pom.xml
+
+      - name: Run tests
+        working-directory: bindings/java
+        run: mvn --batch-mode clean test
+
+  # ============================================
   # Go installed workflow smoke test
   # ============================================
   go-pkgconfig-test:

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ yarn-error.log*
 bindings/typescript/dist/
 *.tsbuildinfo
 
+# Java
+bindings/java/target/
+
 # Native addons
 build/
 *.node

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ npm install @hajewski/latticedb
 
 Published package tarballs are expected to bundle `liblattice` on supported platforms. Source checkouts can stage the native library into the package with `LATTICE_BUNDLE_LIB_DIR=/path/to/lib npm run bundle:native`.
 
+**Java**
+
+Requires JDK 21+. See [bindings/java/README.md](bindings/java/README.md) for the Maven build, which compiles the JNI bridge and stages `liblattice` from `zig-out/lib`. A runnable knowledge-graph example is in [bindings/java/src/main/java/io/latticedb/examples](bindings/java/src/main/java/io/latticedb/examples).
+
 **Go**
 
 See [bindings/go/README.md](bindings/go/README.md) for the current cgo workflow. The default consumer path uses installed `pkg-config` metadata; in-repo development can use `-tags repolocal` against `zig-out/lib`.
@@ -55,7 +59,7 @@ Recent binding-surface cleanups moved embedding helpers into dedicated modules a
 
 ## Start Here
 
-- [Getting Started](docs/getting_started.md) maps the shortest path for CLI, Python, TypeScript, and Go.
+- [Getting Started](docs/getting_started.md) maps the shortest path for CLI, Python, TypeScript, Go, and Java.
 - [CLI Quickstart](examples/cli/README.md) is the smallest copy-paste example in the repo.
 - [Examples Overview](examples/README.md) covers the larger graph/vector/text retrieval demos.
 
@@ -215,6 +219,42 @@ if err != nil {
 }
 ```
 
+### Java
+
+```java
+import io.latticedb.*;
+import java.util.List;
+import java.util.Map;
+
+try (Database db = Database.open("knowledge.db",
+        OpenOptions.defaults().create(true).enableVectors(true).vectorDimensions(128))) {
+
+    // Build a graph
+    try (Transaction txn = db.beginWrite()) {
+        Node chunk = txn.createNode(List.of("Chunk"),
+                Map.of("text", "The transformer architecture uses self-attention..."));
+        txn.setVector(chunk.id(), "embedding",
+                Embedding.hashEmbed("transformer self-attention", 128));
+        txn.ftsIndex(chunk.id(), "The transformer architecture uses self-attention...");
+        txn.commit();
+    }
+
+    // Query across vector search + graph traversal
+    QueryResult results = db.query(
+            "MATCH (chunk:Chunk) " +
+            "WHERE chunk.embedding <=> $query < 0.5 " +
+            "RETURN chunk.text " +
+            "ORDER BY chunk.embedding <=> $query LIMIT 5",
+            Map.of("query", Embedding.hashEmbed("attention mechanism", 128)));
+
+    for (Map<String, Object> row : results.rows()) {
+        System.out.println(row.get("chunk.text"));
+    }
+}
+```
+
+See [bindings/java/README.md](bindings/java/README.md) for build instructions and the full runnable example.
+
 ## Performance
 
 Benchmarked on Apple M1, single-threaded, with auto-scaled buffer pool. Run `zig build benchmark` to reproduce.
@@ -373,7 +413,7 @@ LatticeDB's inverted index with BM25 scoring is ~300x faster than SQLite FTS5 an
 - Online freelist reuse plus `lattice compact` for safe physical tail reclamation
 - Zero configuration — open a file and start working
 - Embedded single-writer model for local applications
-- Clean C API; Python, TypeScript, and Go bindings wrap it
+- Clean C API; Python, TypeScript, Go, and Java bindings wrap it
 
 ## Use Cases
 
@@ -444,6 +484,7 @@ The links below are the in-repo copies and design notes.
 - [Python API Reference](bindings/python/README.md)
 - [TypeScript API Reference](bindings/typescript/README.md)
 - [Go API Reference](bindings/go/README.md)
+- [Java API Reference](bindings/java/README.md)
 - [C API Header](include/lattice.h)
 
 ## License

--- a/bindings/java/README.md
+++ b/bindings/java/README.md
@@ -48,6 +48,15 @@ try (Database db = Database.open("knowledge.db",
     List<VectorSearchResult> near = db.vectorSearch(Embedding.hashEmbed("text", 128),
             VectorSearchOptions.defaults().k(5));
 }
+
+// A snapshot can be stored anywhere and reopened without a file path.
+byte[] snapshot;
+try (Database db = Database.open("knowledge.db")) {
+    snapshot = db.serialize();
+}
+try (Database restored = Database.deserialize(snapshot)) {
+    // use the independent in-memory database
+}
 ```
 
 Run the complete knowledge-graph example after building the shared library:
@@ -58,7 +67,7 @@ mvn -q compile exec:java@run-example -Dexec.args=/tmp/knowledge.db
 
 ## API overview
 
-- `Database`: open/close, `beginRead`/`beginWrite`, `read`/`write` (auto-managed
+- `Database`: open/close, serialize/deserialize, `beginRead`/`beginWrite`, `read`/`write` (auto-managed
   transactions), `query`, `vectorSearch`, `ftsSearch`/`ftsSearchFuzzy`,
   `getNodesByLabel`, property-index create/drop, durable streams
   (`readStream`, `getLastSequence`, `getStreamOffset`, `changes`),

--- a/bindings/java/README.md
+++ b/bindings/java/README.md
@@ -1,0 +1,78 @@
+# LatticeDB Java Bindings
+
+Java 21+ bindings for LatticeDB via JNI, mirroring the Go binding's API surface.
+
+## Build & Test
+
+Prerequisites: JDK 21+, Maven, `zig` (to build `liblattice`), a C compiler (`cc`).
+
+```bash
+# from the repository root: build the native library once
+zig build -Doptimize=ReleaseSafe
+
+# build + test the Java bindings (compiles the JNI bridge into target/native)
+cd bindings/java
+mvn test
+```
+
+The build compiles `native/lattice_jni.c` against `zig-out/lib/liblattice.dylib|so`,
+stages both libraries into `target/native`, and tests load them from there
+(override with `-Dlattice.lib.dir=` or `-Dlatticedb.native.dir=`).
+
+## Usage
+
+```java
+import io.latticedb.*;
+import java.util.List;
+import java.util.Map;
+
+try (Database db = Database.open("knowledge.db",
+        OpenOptions.defaults().create(true).enableVectors(true).vectorDimensions(128))) {
+
+    try (Transaction txn = db.beginWrite()) {
+        Node alice = txn.createNode(List.of("Person"), Map.of("name", "Alice"));
+        Node bob = txn.createNode(List.of("Person"), Map.of("name", "Bob"));
+        txn.createEdge(alice.id(), bob.id(), "KNOWS");
+        txn.setVector(alice.id(), "embedding", Embedding.hashEmbed("text", 128));
+        txn.ftsIndex(bob.id(), "some document text");
+        txn.commit();
+    }
+
+    // Auto-selects read/write transaction mode from the query itself.
+    QueryResult rows = db.query(
+            "MATCH (a:Person)-[:KNOWS]->(b:Person) RETURN b.name AS name",
+            Map.of());
+    rows.rows().forEach(row -> System.out.println(row.get("name")));
+
+    List<FTSSearchResult> hits = db.ftsSearch("document", FTSSearchOptions.defaults());
+    List<VectorSearchResult> near = db.vectorSearch(Embedding.hashEmbed("text", 128),
+            VectorSearchOptions.defaults().k(5));
+}
+```
+
+Run the complete knowledge-graph example after building the shared library:
+
+```bash
+mvn -q compile exec:java@run-example -Dexec.args=/tmp/knowledge.db
+```
+
+## API overview
+
+- `Database`: open/close, `beginRead`/`beginWrite`, `read`/`write` (auto-managed
+  transactions), `query`, `vectorSearch`, `ftsSearch`/`ftsSearchFuzzy`,
+  `getNodesByLabel`, property-index create/drop, durable streams
+  (`readStream`, `getLastSequence`, `getStreamOffset`, `changes`),
+  query-cache stats/clear.
+- `Transaction`: node/edge CRUD with properties (nested `List`/`Map` values,
+  `byte[]`, `float[]` supported), labels, vectors, FTS indexing, equality-index
+  lookups, batch vector insert, stream publish/offsets/trim, Cypher queries,
+  transaction-scoped search (`queryVector`, `ftsSearch`).
+- `Embedding`: deterministic `hashEmbed` plus native HTTP embedding `Client`
+  (Ollama/OpenAI wire formats).
+- Errors: unchecked `LatticeException` (with `ErrorCode`) and `QueryException`
+  carrying stage/diagnostic-code/location diagnostics.
+
+Property values map to Java types as follows: null ↔ `null`, bool ↔ `Boolean`,
+int ↔ `Long`, float ↔ `Double`, string ↔ `String`, bytes ↔ `byte[]`,
+vector ↔ `float[]`, list ↔ `List<Object>`, map ↔ `Map<String,Object>`
+(any `Number`, `List`, or `Map` is accepted on input).

--- a/bindings/java/native/lattice_jni.c
+++ b/bindings/java/native/lattice_jni.c
@@ -32,12 +32,31 @@ static jmethodID MID_LHM_INIT = NULL;
 static jmethodID MID_LHM_PUT = NULL;
 static jclass CLS_BOOL = NULL;
 static jmethodID MID_BOOL_INIT = NULL;
+static jmethodID MID_BOOL_VALUE = NULL;
 static jclass CLS_LONG = NULL;
 static jmethodID MID_LONG_INIT = NULL;
 static jclass CLS_DOUBLE = NULL;
 static jmethodID MID_DOUBLE_INIT = NULL;
+static jclass CLS_FLOAT = NULL;
 static jclass CLS_INTEGER = NULL;
 static jmethodID MID_INT_INIT = NULL;
+static jclass CLS_NUMBER = NULL;
+static jmethodID MID_NUMBER_DOUBLE_VALUE = NULL;
+static jmethodID MID_NUMBER_LONG_VALUE = NULL;
+static jclass CLS_BYTE_ARRAY = NULL;
+static jclass CLS_FLOAT_ARRAY = NULL;
+static jclass CLS_LIST = NULL;
+static jclass CLS_COLLECTION = NULL;
+static jmethodID MID_COLLECTION_ITERATOR = NULL;
+static jclass CLS_ITERATOR = NULL;
+static jmethodID MID_ITERATOR_HAS_NEXT = NULL;
+static jmethodID MID_ITERATOR_NEXT = NULL;
+static jclass CLS_MAP = NULL;
+static jmethodID MID_MAP_ENTRY_SET = NULL;
+static jclass CLS_MAP_ENTRY = NULL;
+static jmethodID MID_MAP_ENTRY_GET_KEY = NULL;
+static jmethodID MID_MAP_ENTRY_GET_VALUE = NULL;
+static jclass CLS_OBJECT = NULL;
 
 static void init_cache(JNIEnv *env) {
     if (CLS_LATTICE_EXCEPTION != NULL) {
@@ -57,12 +76,10 @@ static void init_cache(JNIEnv *env) {
     jclass str = (*env)->FindClass(env, "java/lang/String");
     if (str == NULL) return;
     CLS_STRING = (*env)->NewGlobalRef(env, str);
-    jstring charset = (*env)->NewStringUTF(env, "UTF-8");
     MID_GET_BYTES_UTF8 = (*env)->GetMethodID(env, str, "getBytes",
         "(Ljava/lang/String;)[B");
     MID_STRING_NEW_UTF8 = (*env)->GetMethodID(env, str, "<init>",
         "([BLjava/lang/String;)V");
-    if (charset != NULL) (*env)->DeleteLocalRef(env, charset);
 
     jclass al = (*env)->FindClass(env, "java/util/ArrayList");
     if (al == NULL) return;
@@ -89,6 +106,55 @@ static void init_cache(JNIEnv *env) {
     CACHE_BOX(CLS_DOUBLE, MID_DOUBLE_INIT, "java/lang/Double", "(D)V");
     CACHE_BOX(CLS_INTEGER, MID_INT_INIT, "java/lang/Integer", "(I)V");
 #undef CACHE_BOX
+
+#define CACHE_CLASS(cls_var, name)                                        \
+    do {                                                                   \
+        jclass c = (*env)->FindClass(env, name);                            \
+        if (c == NULL) return;                                              \
+        cls_var = (*env)->NewGlobalRef(env, c);                             \
+    } while (0)
+    CACHE_CLASS(CLS_FLOAT, "java/lang/Float");
+    CACHE_CLASS(CLS_NUMBER, "java/lang/Number");
+    CACHE_CLASS(CLS_BYTE_ARRAY, "[B");
+    CACHE_CLASS(CLS_FLOAT_ARRAY, "[F");
+    CACHE_CLASS(CLS_LIST, "java/util/List");
+    CACHE_CLASS(CLS_COLLECTION, "java/util/Collection");
+    CACHE_CLASS(CLS_ITERATOR, "java/util/Iterator");
+    CACHE_CLASS(CLS_MAP, "java/util/Map");
+    CACHE_CLASS(CLS_MAP_ENTRY, "java/util/Map$Entry");
+    CACHE_CLASS(CLS_OBJECT, "java/lang/Object");
+#undef CACHE_CLASS
+
+    MID_BOOL_VALUE = (*env)->GetMethodID(env, CLS_BOOL, "booleanValue", "()Z");
+    MID_NUMBER_DOUBLE_VALUE = (*env)->GetMethodID(env, CLS_NUMBER,
+        "doubleValue", "()D");
+    MID_NUMBER_LONG_VALUE = (*env)->GetMethodID(env, CLS_NUMBER,
+        "longValue", "()J");
+    MID_COLLECTION_ITERATOR = (*env)->GetMethodID(env, CLS_COLLECTION,
+        "iterator", "()Ljava/util/Iterator;");
+    MID_ITERATOR_HAS_NEXT = (*env)->GetMethodID(env, CLS_ITERATOR,
+        "hasNext", "()Z");
+    MID_ITERATOR_NEXT = (*env)->GetMethodID(env, CLS_ITERATOR,
+        "next", "()Ljava/lang/Object;");
+    MID_MAP_ENTRY_SET = (*env)->GetMethodID(env, CLS_MAP, "entrySet",
+        "()Ljava/util/Set;");
+    MID_MAP_ENTRY_GET_KEY = (*env)->GetMethodID(env, CLS_MAP_ENTRY,
+        "getKey", "()Ljava/lang/Object;");
+    MID_MAP_ENTRY_GET_VALUE = (*env)->GetMethodID(env, CLS_MAP_ENTRY,
+        "getValue", "()Ljava/lang/Object;");
+}
+
+JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved) {
+    (void)reserved;
+    JNIEnv *env = NULL;
+    if ((*vm)->GetEnv(vm, (void **)&env, JNI_VERSION_1_8) != JNI_OK) {
+        return JNI_ERR;
+    }
+    init_cache(env);
+    if ((*env)->ExceptionCheck(env)) {
+        return JNI_ERR;
+    }
+    return JNI_VERSION_1_8;
 }
 
 /* Throw LatticeException(code, message). Always returns a default value
@@ -250,30 +316,25 @@ static int fill_value_inner(JNIEnv *env, lattice_value *dst, jobject value) {
     }
 
     /* Boolean */
-    jclass bcls = (*env)->FindClass(env, "java/lang/Boolean");
-    if ((*env)->IsInstanceOf(env, value, bcls)) {
+    if ((*env)->IsInstanceOf(env, value, CLS_BOOL)) {
         memset(dst, 0, sizeof(*dst));
         dst->type = LATTICE_VALUE_BOOL;
-        jmethodID bv = (*env)->GetMethodID(env, bcls, "booleanValue", "()Z");
-        dst->data.bool_val = (*env)->CallBooleanMethod(env, value, bv);
+        dst->data.bool_val = (*env)->CallBooleanMethod(env, value, MID_BOOL_VALUE);
         return 1;
     }
 
     /* Numbers: integral types -> INT, floating types -> FLOAT */
-    jclass ncls = (*env)->FindClass(env, "java/lang/Number");
-    if ((*env)->IsInstanceOf(env, value, ncls)) {
+    if ((*env)->IsInstanceOf(env, value, CLS_NUMBER)) {
         memset(dst, 0, sizeof(*dst));
-        jclass dcls = (*env)->FindClass(env, "java/lang/Double");
-        jclass fcls = (*env)->FindClass(env, "java/lang/Float");
-        if ((*env)->IsInstanceOf(env, value, dcls) ||
-            (*env)->IsInstanceOf(env, value, fcls)) {
+        if ((*env)->IsInstanceOf(env, value, CLS_DOUBLE) ||
+            (*env)->IsInstanceOf(env, value, CLS_FLOAT)) {
             dst->type = LATTICE_VALUE_FLOAT;
-            jmethodID dv = (*env)->GetMethodID(env, ncls, "doubleValue", "()D");
-            dst->data.float_val = (*env)->CallDoubleMethod(env, value, dv);
+            dst->data.float_val = (*env)->CallDoubleMethod(env, value,
+                                                            MID_NUMBER_DOUBLE_VALUE);
         } else {
             dst->type = LATTICE_VALUE_INT;
-            jmethodID lv = (*env)->GetMethodID(env, ncls, "longValue", "()J");
-            dst->data.int_val = (*env)->CallLongMethod(env, value, lv);
+            dst->data.int_val = (*env)->CallLongMethod(env, value,
+                                                        MID_NUMBER_LONG_VALUE);
         }
         return 1;
     }
@@ -284,8 +345,7 @@ static int fill_value_inner(JNIEnv *env, lattice_value *dst, jobject value) {
     }
 
     /* byte[] -> BYTES */
-    jclass byteArr = (*env)->FindClass(env, "[B");
-    if ((*env)->IsInstanceOf(env, value, byteArr)) {
+    if ((*env)->IsInstanceOf(env, value, CLS_BYTE_ARRAY)) {
         jbyteArray arr = (jbyteArray)value;
         jsize len = (*env)->GetArrayLength(env, arr);
         uint8_t *buf = NULL;
@@ -302,8 +362,7 @@ static int fill_value_inner(JNIEnv *env, lattice_value *dst, jobject value) {
     }
 
     /* float[] -> VECTOR */
-    jclass floatArr = (*env)->FindClass(env, "[F");
-    if ((*env)->IsInstanceOf(env, value, floatArr)) {
+    if ((*env)->IsInstanceOf(env, value, CLS_FLOAT_ARRAY)) {
         jfloatArray arr = (jfloatArray)value;
         jsize len = (*env)->GetArrayLength(env, arr);
         float *buf = NULL;
@@ -320,17 +379,9 @@ static int fill_value_inner(JNIEnv *env, lattice_value *dst, jobject value) {
     }
 
     /* java.util.List -> LIST */
-    jclass listCls = (*env)->FindClass(env, "java/util/List");
-    if ((*env)->IsInstanceOf(env, value, listCls)) {
+    if ((*env)->IsInstanceOf(env, value, CLS_LIST)) {
         jobject iter = NULL;
-        jclass collCls = (*env)->FindClass(env, "java/util/Collection");
-        jmethodID iteratorM = (*env)->GetMethodID(env, collCls, "iterator",
-                                                  "()Ljava/util/Iterator;");
-        jmethodID hasNextM = NULL, nextM = NULL;
-        jclass iterCls = (*env)->FindClass(env, "java/util/Iterator");
-        hasNextM = (*env)->GetMethodID(env, iterCls, "hasNext", "()Z");
-        nextM = (*env)->GetMethodID(env, iterCls, "next", "()Ljava/lang/Object;");
-        iter = (*env)->CallObjectMethod(env, value, iteratorM);
+        iter = (*env)->CallObjectMethod(env, value, MID_COLLECTION_ITERATOR);
 
         lattice_list *list = (lattice_list *)calloc(1, sizeof(lattice_list));
         if (list == NULL) {
@@ -344,8 +395,8 @@ static int fill_value_inner(JNIEnv *env, lattice_value *dst, jobject value) {
             throw_lattice(env, LATTICE_ERROR_OUT_OF_MEMORY);
             return 0;
         }
-        while ((*env)->CallBooleanMethod(env, iter, hasNextM)) {
-            jobject item = (*env)->CallObjectMethod(env, iter, nextM);
+        while ((*env)->CallBooleanMethod(env, iter, MID_ITERATOR_HAS_NEXT)) {
+            jobject item = (*env)->CallObjectMethod(env, iter, MID_ITERATOR_NEXT);
             if (list->len == cap) {
                 cap *= 2;
                 lattice_value *grown = (lattice_value *)
@@ -372,23 +423,9 @@ static int fill_value_inner(JNIEnv *env, lattice_value *dst, jobject value) {
     }
 
     /* java.util.Map -> MAP */
-    jclass mapCls = (*env)->FindClass(env, "java/util/Map");
-    if ((*env)->IsInstanceOf(env, value, mapCls)) {
-        jmethodID entrySetM = (*env)->GetMethodID(env, mapCls, "entrySet",
-                                                  "()Ljava/util/Set;");
-        jobject entrySet = (*env)->CallObjectMethod(env, value, entrySetM);
-        jclass setCls = (*env)->FindClass(env, "java/util/Set");
-        jmethodID iteratorM = (*env)->GetMethodID(env, setCls, "iterator",
-                                                  "()Ljava/util/Iterator;");
-        jclass iterCls = (*env)->FindClass(env, "java/util/Iterator");
-        jmethodID hasNextM = (*env)->GetMethodID(env, iterCls, "hasNext", "()Z");
-        jmethodID nextM = (*env)->GetMethodID(env, iterCls, "next", "()Ljava/lang/Object;");
-        jclass entryCls = (*env)->FindClass(env, "java/util/Map$Entry");
-        jmethodID getKeyM = (*env)->GetMethodID(env, entryCls, "getKey",
-                                                "()Ljava/lang/Object;");
-        jmethodID getValueM = (*env)->GetMethodID(env, entryCls, "getValue",
-                                                  "()Ljava/lang/Object;");
-        jobject iter = (*env)->CallObjectMethod(env, entrySet, iteratorM);
+    if ((*env)->IsInstanceOf(env, value, CLS_MAP)) {
+        jobject entrySet = (*env)->CallObjectMethod(env, value, MID_MAP_ENTRY_SET);
+        jobject iter = (*env)->CallObjectMethod(env, entrySet, MID_COLLECTION_ITERATOR);
 
         lattice_map *map = (lattice_map *)calloc(1, sizeof(lattice_map));
         if (map == NULL) {
@@ -402,10 +439,10 @@ static int fill_value_inner(JNIEnv *env, lattice_value *dst, jobject value) {
             throw_lattice(env, LATTICE_ERROR_OUT_OF_MEMORY);
             return 0;
         }
-        while ((*env)->CallBooleanMethod(env, iter, hasNextM)) {
-            jobject entry = (*env)->CallObjectMethod(env, iter, nextM);
-            jobject key_obj = (*env)->CallObjectMethod(env, entry, getKeyM);
-            jobject val = (*env)->CallObjectMethod(env, entry, getValueM);
+        while ((*env)->CallBooleanMethod(env, iter, MID_ITERATOR_HAS_NEXT)) {
+            jobject entry = (*env)->CallObjectMethod(env, iter, MID_ITERATOR_NEXT);
+            jobject key_obj = (*env)->CallObjectMethod(env, entry, MID_MAP_ENTRY_GET_KEY);
+            jobject val = (*env)->CallObjectMethod(env, entry, MID_MAP_ENTRY_GET_VALUE);
             if (key_obj == NULL || !(*env)->IsInstanceOf(env, key_obj, CLS_STRING)) {
                 map->len = count;
                 free_map(map);
@@ -564,10 +601,10 @@ JNIEXPORT jlong JNICALL
 Java_io_latticedb_Native_open(JNIEnv *env, jclass cls, jstring path,
         jboolean create, jboolean read_only, jint cache_size_mb, jint page_size,
         jboolean enable_vector, jint vector_dimensions, jboolean enable_wal,
-        jboolean enable_adjacency_cache) {
+        jboolean enable_adjacency_cache, jboolean lock) {
     init_cache(env);
     (void)cls;
-    lattice_open_options_v3 opts;
+    lattice_open_options_v4 opts;
     memset(&opts, 0, sizeof(opts));
     opts.struct_size = sizeof(opts);
     opts.create = create == JNI_TRUE;
@@ -578,14 +615,81 @@ Java_io_latticedb_Native_open(JNIEnv *env, jclass cls, jstring path,
     opts.vector_dimensions = vector_dimensions <= 0 ? 128 : (uint16_t)vector_dimensions;
     opts.enable_wal = enable_wal == JNI_TRUE;
     opts.enable_adjacency_cache = enable_adjacency_cache == JNI_TRUE;
+    opts.lock = lock == JNI_TRUE;
 
     size_t path_len = 0;
     char *path_buf = jstring_to_utf8(env, path, &path_len);
     if (path_buf == NULL && (*env)->ExceptionCheck(env)) return 0;
 
     lattice_database *db = NULL;
-    lattice_error rc = lattice_open_v3(path_buf, &opts, &db);
+    lattice_error rc = lattice_open_v4(path_buf, &opts, &db);
     free(path_buf);
+    if (!check(env, rc)) return 0;
+    return (jlong)(uintptr_t)db;
+}
+
+JNIEXPORT jbyteArray JNICALL
+Java_io_latticedb_Native_serialize(JNIEnv *env, jclass cls, jlong db_handle) {
+    init_cache(env);
+    (void)cls;
+    uint8_t *bytes = NULL;
+    size_t len = 0;
+    lattice_error rc = lattice_serialize(
+        (lattice_database *)(uintptr_t)db_handle, &bytes, &len);
+    if (!check(env, rc)) return NULL;
+    if (len > INT32_MAX) {
+        lattice_free_bytes(bytes, len);
+        throw_lattice(env, LATTICE_ERROR_VALUE_TOO_LARGE);
+        return NULL;
+    }
+
+    jbyteArray out = (*env)->NewByteArray(env, (jsize)len);
+    if (out == NULL) {
+        lattice_free_bytes(bytes, len);
+        return NULL;
+    }
+    if (len > 0) {
+        (*env)->SetByteArrayRegion(env, out, 0, (jsize)len, (const jbyte *)bytes);
+    }
+    lattice_free_bytes(bytes, len);
+    return out;
+}
+
+JNIEXPORT jlong JNICALL
+Java_io_latticedb_Native_deserialize(JNIEnv *env, jclass cls, jbyteArray bytes,
+        jint cache_size_mb, jint page_size, jboolean enable_vector,
+        jint vector_dimensions, jboolean enable_wal,
+        jboolean enable_adjacency_cache, jboolean lock) {
+    init_cache(env);
+    (void)cls;
+    if (bytes == NULL) {
+        throw_lattice(env, LATTICE_ERROR_INVALID_ARG);
+        return 0;
+    }
+
+    lattice_open_options_v4 opts;
+    memset(&opts, 0, sizeof(opts));
+    opts.struct_size = sizeof(opts);
+    opts.create = false;
+    opts.read_only = false;
+    opts.cache_size_mb = cache_size_mb <= 0 ? 100 : (uint32_t)cache_size_mb;
+    opts.page_size = page_size <= 0 ? 4096 : (uint32_t)page_size;
+    opts.enable_vector = enable_vector == JNI_TRUE;
+    opts.vector_dimensions = vector_dimensions <= 0 ? 128 : (uint16_t)vector_dimensions;
+    opts.enable_wal = enable_wal == JNI_TRUE;
+    opts.enable_adjacency_cache = enable_adjacency_cache == JNI_TRUE;
+    opts.lock = lock == JNI_TRUE;
+
+    jsize len = (*env)->GetArrayLength(env, bytes);
+    jbyte *data = len > 0 ? (*env)->GetByteArrayElements(env, bytes, NULL) : NULL;
+    if (len > 0 && data == NULL) return 0;
+
+    lattice_database *db = NULL;
+    lattice_error rc = lattice_deserialize(
+        (const uint8_t *)data, (size_t)len, &opts, &db);
+    if (data != NULL) {
+        (*env)->ReleaseByteArrayElements(env, bytes, data, JNI_ABORT);
+    }
     if (!check(env, rc)) return 0;
     return (jlong)(uintptr_t)db;
 }
@@ -1155,8 +1259,7 @@ static jobjectArray fetch_edges(JNIEnv *env, jlong txn_handle, jint which,
     if (n > 0) (*env)->SetLongArrayRegion(env, idsArr, 0, (jsize)(3 * n), triples);
     free(triples);
 
-    jobjectArray out = (*env)->NewObjectArray(env, 2,
-        (*env)->FindClass(env, "java/lang/Object"), NULL);
+    jobjectArray out = (*env)->NewObjectArray(env, 2, CLS_OBJECT, NULL);
     if (out == NULL) return NULL;
     (*env)->SetObjectArrayElement(env, out, 0, idsArr);
     (*env)->SetObjectArrayElement(env, out, 1, types);
@@ -1254,8 +1357,7 @@ static jobject search_vectors(JNIEnv *env, jlong db_handle, jlong txn_handle,
         (*env)->SetFloatArrayRegion(env, distsArr, 0, (jsize)n, dists);
     }
     free(ids); free(dists);
-    jobjectArray out = (*env)->NewObjectArray(env, 2,
-        (*env)->FindClass(env, "java/lang/Object"), NULL);
+    jobjectArray out = (*env)->NewObjectArray(env, 2, CLS_OBJECT, NULL);
     if (out == NULL) return NULL;
     (*env)->SetObjectArrayElement(env, out, 0, idsArr);
     (*env)->SetObjectArrayElement(env, out, 1, distsArr);
@@ -1355,8 +1457,7 @@ static jobject fts_search(JNIEnv *env, jlong db_handle, jlong txn_handle, jint u
         (*env)->SetFloatArrayRegion(env, scoresArr, 0, (jsize)n, scores);
     }
     free(ids); free(scores);
-    jobjectArray out = (*env)->NewObjectArray(env, 2,
-        (*env)->FindClass(env, "java/lang/Object"), NULL);
+    jobjectArray out = (*env)->NewObjectArray(env, 2, CLS_OBJECT, NULL);
     if (out == NULL) return NULL;
     (*env)->SetObjectArrayElement(env, out, 0, idsArr);
     (*env)->SetObjectArrayElement(env, out, 1, scoresArr);
@@ -1462,8 +1563,7 @@ Java_io_latticedb_Native_streamRead(JNIEnv *env, jclass cls, jlong db_handle,
     size_t n = batch ? lattice_stream_batch_count(batch) : 0;
     jlong *seqs = (jlong *)malloc(sizeof(jlong) * (n > 0 ? n : 1));
     jobjectArray kinds = (*env)->NewObjectArray(env, (jsize)n, CLS_STRING, NULL);
-    jobjectArray payloads = (*env)->NewObjectArray(env, (jsize)n,
-        (*env)->FindClass(env, "java/lang/Object"), NULL);
+    jobjectArray payloads = (*env)->NewObjectArray(env, (jsize)n, CLS_OBJECT, NULL);
     if (seqs == NULL || kinds == NULL || payloads == NULL) {
         free(seqs); lattice_stream_batch_free(batch);
         throw_lattice(env, LATTICE_ERROR_OUT_OF_MEMORY);
@@ -1494,8 +1594,7 @@ Java_io_latticedb_Native_streamRead(JNIEnv *env, jclass cls, jlong db_handle,
     if (n > 0) (*env)->SetLongArrayRegion(env, seqsArr, 0, (jsize)n, seqs);
     free(seqs);
 
-    jobjectArray out = (*env)->NewObjectArray(env, 3,
-        (*env)->FindClass(env, "java/lang/Object"), NULL);
+    jobjectArray out = (*env)->NewObjectArray(env, 3, CLS_OBJECT, NULL);
     if (out == NULL) return NULL;
     (*env)->SetObjectArrayElement(env, out, 0, seqsArr);
     (*env)->SetObjectArrayElement(env, out, 1, kinds);
@@ -1519,8 +1618,7 @@ Java_io_latticedb_Native_streamGetOffset(JNIEnv *env, jclass cls, jlong db_handl
     free(s); free(c);
     if (!check(env, rc)) return NULL;
 
-    jobjectArray out = (*env)->NewObjectArray(env, 2,
-        (*env)->FindClass(env, "java/lang/Object"), NULL);
+    jobjectArray out = (*env)->NewObjectArray(env, 2, CLS_OBJECT, NULL);
     if (out == NULL) return NULL;
     jobject off = (*env)->NewObject(env, CLS_LONG, MID_LONG_INIT, (jlong)sequence);
     jobject bex = (*env)->NewObject(env, CLS_BOOL, MID_BOOL_INIT,
@@ -1723,8 +1821,7 @@ Java_io_latticedb_Native_cacheStats(JNIEnv *env, jclass cls, jlong db_handle) {
     lattice_error rc = lattice_query_cache_stats(
         (lattice_database *)(uintptr_t)db_handle, &entries, &hits, &misses);
     if (!check(env, rc)) return NULL;
-    jobjectArray out = (*env)->NewObjectArray(env, 3,
-        (*env)->FindClass(env, "java/lang/Object"), NULL);
+    jobjectArray out = (*env)->NewObjectArray(env, 3, CLS_OBJECT, NULL);
     if (out == NULL) return NULL;
     jobject e = (*env)->NewObject(env, CLS_INTEGER, MID_INT_INIT, (jint)entries);
     jobject h = (*env)->NewObject(env, CLS_LONG, MID_LONG_INIT, (jlong)hits);

--- a/bindings/java/native/lattice_jni.c
+++ b/bindings/java/native/lattice_jni.c
@@ -1,0 +1,1820 @@
+/*
+ * LatticeDB Java bindings - JNI bridge.
+ *
+ * Wraps the stable C API (include/lattice.h) for the io.latticedb Java
+ * package. Mirrors the Go cgo bridge (bindings/go/internal/cgo) in behavior:
+ * same ownership rules, same error propagation, same value conversions.
+ */
+
+#include <jni.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+#include "lattice.h"
+
+/* ------------------------------------------------------------------ */
+/* Cached JNI references                                               */
+/* ------------------------------------------------------------------ */
+
+static jclass CLS_LATTICE_EXCEPTION = NULL;
+static jmethodID MID_LATTICE_INIT = NULL;
+static jclass CLS_QUERY_EXCEPTION = NULL;
+static jmethodID MID_QUERY_EXCEPTION_INIT = NULL;
+static jclass CLS_STRING = NULL;
+static jmethodID MID_GET_BYTES_UTF8 = NULL;
+static jmethodID MID_STRING_NEW_UTF8 = NULL;
+static jclass CLS_ARRAYLIST = NULL;
+static jmethodID MID_ARRAYLIST_INIT = NULL;
+static jmethodID MID_ARRAYLIST_ADD = NULL;
+static jclass CLS_LINKED_HASH_MAP = NULL;
+static jmethodID MID_LHM_INIT = NULL;
+static jmethodID MID_LHM_PUT = NULL;
+static jclass CLS_BOOL = NULL;
+static jmethodID MID_BOOL_INIT = NULL;
+static jclass CLS_LONG = NULL;
+static jmethodID MID_LONG_INIT = NULL;
+static jclass CLS_DOUBLE = NULL;
+static jmethodID MID_DOUBLE_INIT = NULL;
+static jclass CLS_INTEGER = NULL;
+static jmethodID MID_INT_INIT = NULL;
+
+static void init_cache(JNIEnv *env) {
+    if (CLS_LATTICE_EXCEPTION != NULL) {
+        return;
+    }
+    jclass le = (*env)->FindClass(env, "io/latticedb/LatticeException");
+    if (le == NULL) return;
+    CLS_LATTICE_EXCEPTION = (*env)->NewGlobalRef(env, le);
+    MID_LATTICE_INIT = (*env)->GetMethodID(env, le, "<init>", "(ILjava/lang/String;)V");
+
+    jclass qe = (*env)->FindClass(env, "io/latticedb/QueryException");
+    if (qe == NULL) return;
+    CLS_QUERY_EXCEPTION = (*env)->NewGlobalRef(env, qe);
+    MID_QUERY_EXCEPTION_INIT = (*env)->GetMethodID(env, qe, "<init>",
+        "(IILjava/lang/String;Ljava/lang/String;ZIII)V");
+
+    jclass str = (*env)->FindClass(env, "java/lang/String");
+    if (str == NULL) return;
+    CLS_STRING = (*env)->NewGlobalRef(env, str);
+    jstring charset = (*env)->NewStringUTF(env, "UTF-8");
+    MID_GET_BYTES_UTF8 = (*env)->GetMethodID(env, str, "getBytes",
+        "(Ljava/lang/String;)[B");
+    MID_STRING_NEW_UTF8 = (*env)->GetMethodID(env, str, "<init>",
+        "([BLjava/lang/String;)V");
+    if (charset != NULL) (*env)->DeleteLocalRef(env, charset);
+
+    jclass al = (*env)->FindClass(env, "java/util/ArrayList");
+    if (al == NULL) return;
+    CLS_ARRAYLIST = (*env)->NewGlobalRef(env, al);
+    MID_ARRAYLIST_INIT = (*env)->GetMethodID(env, al, "<init>", "(I)V");
+    MID_ARRAYLIST_ADD = (*env)->GetMethodID(env, al, "add", "(Ljava/lang/Object;)Z");
+
+    jclass lhm = (*env)->FindClass(env, "java/util/LinkedHashMap");
+    if (lhm == NULL) return;
+    CLS_LINKED_HASH_MAP = (*env)->NewGlobalRef(env, lhm);
+    MID_LHM_INIT = (*env)->GetMethodID(env, lhm, "<init>", "()V");
+    MID_LHM_PUT = (*env)->GetMethodID(env, lhm, "put",
+        "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");
+
+#define CACHE_BOX(cls_var, mid_var, name, sig)                              \
+    do {                                                                    \
+        jclass c = (*env)->FindClass(env, name);                            \
+        if (c == NULL) return;                                              \
+        cls_var = (*env)->NewGlobalRef(env, c);                             \
+        mid_var = (*env)->GetMethodID(env, c, "<init>", sig);               \
+    } while (0)
+    CACHE_BOX(CLS_BOOL, MID_BOOL_INIT, "java/lang/Boolean", "(Z)V");
+    CACHE_BOX(CLS_LONG, MID_LONG_INIT, "java/lang/Long", "(J)V");
+    CACHE_BOX(CLS_DOUBLE, MID_DOUBLE_INIT, "java/lang/Double", "(D)V");
+    CACHE_BOX(CLS_INTEGER, MID_INT_INIT, "java/lang/Integer", "(I)V");
+#undef CACHE_BOX
+}
+
+/* Throw LatticeException(code, message). Always returns a default value
+ * suitable for the caller's return type after use. */
+static void throw_lattice(JNIEnv *env, lattice_error code) {
+    const char *msg = lattice_error_message(code);
+    jstring jmsg = (*env)->NewStringUTF(env, msg ? msg : "");
+    jobject ex = (*env)->NewObject(env, CLS_LATTICE_EXCEPTION, MID_LATTICE_INIT,
+                                   (jint)code, jmsg);
+    if (ex != NULL) (*env)->Throw(env, ex);
+    if (jmsg != NULL) (*env)->DeleteLocalRef(env, jmsg);
+}
+
+static int check(JNIEnv *env, lattice_error code) {
+    if (code != LATTICE_OK) {
+        throw_lattice(env, code);
+        return 0;
+    }
+    return 1;
+}
+
+/* Build and throw a QueryException from the prepared-query diagnostics. */
+static void throw_query_error(JNIEnv *env, lattice_query *q) {
+    jint stage = (jint)lattice_query_last_error_stage(q);
+    const char *msg = lattice_query_last_error_message(q);
+    const char *diag = lattice_query_last_error_code(q);
+    jint code = -1; /* generic */
+    jboolean has_loc = lattice_query_last_error_has_location(q) ? JNI_TRUE : JNI_FALSE;
+    jint line = (jint)lattice_query_last_error_line(q);
+    jint column = (jint)lattice_query_last_error_column(q);
+    jint length = (jint)lattice_query_last_error_length(q);
+    jstring jmsg = (*env)->NewStringUTF(env, msg ? msg : "");
+    jstring jdiag = diag ? (*env)->NewStringUTF(env, diag) : NULL;
+    jobject ex = (*env)->NewObject(env, CLS_QUERY_EXCEPTION, MID_QUERY_EXCEPTION_INIT,
+        code, stage, jmsg, jdiag, has_loc, line, column, length);
+    if (ex != NULL) (*env)->Throw(env, ex);
+    if (jmsg) (*env)->DeleteLocalRef(env, jmsg);
+    if (jdiag) (*env)->DeleteLocalRef(env, jdiag);
+}
+
+/* ------------------------------------------------------------------ */
+/* UTF-8 string helpers                                                */
+/* ------------------------------------------------------------------ */
+
+/* Convert a jstring to a NUL-terminated UTF-8 buffer (malloc'd).
+ * Returns NULL (with an exception pending) on failure.
+ * The returned length excludes the NUL terminator. */
+static char *jstring_to_utf8(JNIEnv *env, jstring str, size_t *out_len) {
+    *out_len = 0;
+    if (str == NULL) return NULL;
+    jstring charset = (*env)->NewStringUTF(env, "UTF-8");
+    if (charset == NULL) return NULL;
+    jbyteArray bytes = (jbyteArray)(*env)->CallObjectMethod(env, str,
+                                                            MID_GET_BYTES_UTF8,
+                                                            charset);
+    (*env)->DeleteLocalRef(env, charset);
+    if (bytes == NULL || (*env)->ExceptionCheck(env)) return NULL;
+    jsize len = (*env)->GetArrayLength(env, bytes);
+    char *buf = (char *)malloc((size_t)len + 1);
+    if (buf == NULL) {
+        (*env)->DeleteLocalRef(env, bytes);
+        throw_lattice(env, LATTICE_ERROR_OUT_OF_MEMORY);
+        return NULL;
+    }
+    if (len > 0) {
+        (*env)->GetByteArrayRegion(env, bytes, 0, len, (jbyte *)buf);
+    }
+    buf[len] = '\0';
+    (*env)->DeleteLocalRef(env, bytes);
+    *out_len = (size_t)len;
+    return buf;
+}
+
+/* Convert a UTF-8 buffer to a jstring without going through modified UTF-8. */
+static jstring utf8_to_jstring(JNIEnv *env, const char *ptr, size_t len) {
+    if (ptr == NULL) return NULL;
+    jbyteArray bytes = (*env)->NewByteArray(env, (jsize)len);
+    if (bytes == NULL) return NULL;
+    if (len > 0) {
+        (*env)->SetByteArrayRegion(env, bytes, 0, (jsize)len, (const jbyte *)ptr);
+    }
+    jstring charset = (*env)->NewStringUTF(env, "UTF-8");
+    jstring result = (jstring)(*env)->NewObject(env, CLS_STRING,
+                                                MID_STRING_NEW_UTF8, bytes, charset);
+    (*env)->DeleteLocalRef(env, charset);
+    (*env)->DeleteLocalRef(env, bytes);
+    return result;
+}
+
+/* ------------------------------------------------------------------ */
+/* Value conversion: Java Object -> lattice_value tree                 */
+/*                                                                     */
+/* Values passed to the native layer are borrowed for the call, so we   */
+/* build a self-contained tree with malloc and free it after the call.  */
+/* ------------------------------------------------------------------ */
+
+static int fill_value_inner(JNIEnv *env, lattice_value *dst, jobject value);
+
+/* Give each recursive conversion its own local-reference frame. Large nested
+ * collections would otherwise retain several JNI class/object references per
+ * element until the native entry point returned. */
+static int fill_value(JNIEnv *env, lattice_value *dst, jobject value) {
+    if ((*env)->PushLocalFrame(env, 24) < 0) return 0;
+    int ok = fill_value_inner(env, dst, value);
+    (*env)->PopLocalFrame(env, NULL);
+    return ok;
+}
+
+static void free_value_tree(lattice_value *v);
+
+static void free_list(lattice_list *list) {
+    if (list == NULL) return;
+    for (size_t i = 0; i < list->len; i++) free_value_tree(&list->items[i]);
+    free(list->items);
+    free(list);
+}
+
+static void free_map(lattice_map *map) {
+    if (map == NULL) return;
+    for (size_t i = 0; i < map->len; i++) {
+        free((void *)map->entries[i].key);
+        free_value_tree(&map->entries[i].value);
+    }
+    free(map->entries);
+    free(map);
+}
+
+static void free_value_tree(lattice_value *v) {
+    if (v == NULL) return;
+    switch (v->type) {
+        case LATTICE_VALUE_STRING: free((void *)v->data.string_val.ptr); break;
+        case LATTICE_VALUE_BYTES:  free((void *)v->data.bytes_val.ptr); break;
+        case LATTICE_VALUE_VECTOR: free((void *)v->data.vector_val.ptr); break;
+        case LATTICE_VALUE_LIST:   free_list(v->data.list_val); break;
+        case LATTICE_VALUE_MAP:    free_map(v->data.map_val); break;
+        default: break;
+    }
+}
+
+static int fill_string(JNIEnv *env, lattice_value *dst, jstring str) {
+    memset(dst, 0, sizeof(*dst));
+    size_t len = 0;
+    char *buf = jstring_to_utf8(env, str, &len);
+    if (buf == NULL && !(*env)->ExceptionCheck(env)) {
+        /* null string maps to empty */
+    }
+    if ((*env)->ExceptionCheck(env)) { free(buf); return 0; }
+    dst->type = LATTICE_VALUE_STRING;
+    dst->data.string_val.ptr = buf;
+    dst->data.string_val.len = buf ? len : 0;
+    return 1;
+}
+
+static int fill_value_inner(JNIEnv *env, lattice_value *dst, jobject value) {
+    if (value == NULL) {
+        memset(dst, 0, sizeof(*dst));
+        dst->type = LATTICE_VALUE_NULL;
+        return 1;
+    }
+
+    /* Boolean */
+    jclass bcls = (*env)->FindClass(env, "java/lang/Boolean");
+    if ((*env)->IsInstanceOf(env, value, bcls)) {
+        memset(dst, 0, sizeof(*dst));
+        dst->type = LATTICE_VALUE_BOOL;
+        jmethodID bv = (*env)->GetMethodID(env, bcls, "booleanValue", "()Z");
+        dst->data.bool_val = (*env)->CallBooleanMethod(env, value, bv);
+        return 1;
+    }
+
+    /* Numbers: integral types -> INT, floating types -> FLOAT */
+    jclass ncls = (*env)->FindClass(env, "java/lang/Number");
+    if ((*env)->IsInstanceOf(env, value, ncls)) {
+        memset(dst, 0, sizeof(*dst));
+        jclass dcls = (*env)->FindClass(env, "java/lang/Double");
+        jclass fcls = (*env)->FindClass(env, "java/lang/Float");
+        if ((*env)->IsInstanceOf(env, value, dcls) ||
+            (*env)->IsInstanceOf(env, value, fcls)) {
+            dst->type = LATTICE_VALUE_FLOAT;
+            jmethodID dv = (*env)->GetMethodID(env, ncls, "doubleValue", "()D");
+            dst->data.float_val = (*env)->CallDoubleMethod(env, value, dv);
+        } else {
+            dst->type = LATTICE_VALUE_INT;
+            jmethodID lv = (*env)->GetMethodID(env, ncls, "longValue", "()J");
+            dst->data.int_val = (*env)->CallLongMethod(env, value, lv);
+        }
+        return 1;
+    }
+
+    /* String */
+    if ((*env)->IsInstanceOf(env, value, CLS_STRING)) {
+        return fill_string(env, dst, (jstring)value);
+    }
+
+    /* byte[] -> BYTES */
+    jclass byteArr = (*env)->FindClass(env, "[B");
+    if ((*env)->IsInstanceOf(env, value, byteArr)) {
+        jbyteArray arr = (jbyteArray)value;
+        jsize len = (*env)->GetArrayLength(env, arr);
+        uint8_t *buf = NULL;
+        if (len > 0) {
+            buf = (uint8_t *)malloc((size_t)len);
+            if (buf == NULL) { throw_lattice(env, LATTICE_ERROR_OUT_OF_MEMORY); return 0; }
+            (*env)->GetByteArrayRegion(env, arr, 0, len, (jbyte *)buf);
+        }
+        memset(dst, 0, sizeof(*dst));
+        dst->type = LATTICE_VALUE_BYTES;
+        dst->data.bytes_val.ptr = buf;
+        dst->data.bytes_val.len = (size_t)(len > 0 ? len : 0);
+        return 1;
+    }
+
+    /* float[] -> VECTOR */
+    jclass floatArr = (*env)->FindClass(env, "[F");
+    if ((*env)->IsInstanceOf(env, value, floatArr)) {
+        jfloatArray arr = (jfloatArray)value;
+        jsize len = (*env)->GetArrayLength(env, arr);
+        float *buf = NULL;
+        if (len > 0) {
+            buf = (float *)malloc(sizeof(float) * (size_t)len);
+            if (buf == NULL) { throw_lattice(env, LATTICE_ERROR_OUT_OF_MEMORY); return 0; }
+            (*env)->GetFloatArrayRegion(env, arr, 0, len, buf);
+        }
+        memset(dst, 0, sizeof(*dst));
+        dst->type = LATTICE_VALUE_VECTOR;
+        dst->data.vector_val.ptr = buf;
+        dst->data.vector_val.dimensions = (uint32_t)(len > 0 ? len : 0);
+        return 1;
+    }
+
+    /* java.util.List -> LIST */
+    jclass listCls = (*env)->FindClass(env, "java/util/List");
+    if ((*env)->IsInstanceOf(env, value, listCls)) {
+        jobject iter = NULL;
+        jclass collCls = (*env)->FindClass(env, "java/util/Collection");
+        jmethodID iteratorM = (*env)->GetMethodID(env, collCls, "iterator",
+                                                  "()Ljava/util/Iterator;");
+        jmethodID hasNextM = NULL, nextM = NULL;
+        jclass iterCls = (*env)->FindClass(env, "java/util/Iterator");
+        hasNextM = (*env)->GetMethodID(env, iterCls, "hasNext", "()Z");
+        nextM = (*env)->GetMethodID(env, iterCls, "next", "()Ljava/lang/Object;");
+        iter = (*env)->CallObjectMethod(env, value, iteratorM);
+
+        lattice_list *list = (lattice_list *)calloc(1, sizeof(lattice_list));
+        if (list == NULL) {
+            throw_lattice(env, LATTICE_ERROR_OUT_OF_MEMORY);
+            return 0;
+        }
+        size_t cap = 8;
+        list->items = (lattice_value *)calloc(cap, sizeof(lattice_value));
+        if (list->items == NULL) {
+            free(list);
+            throw_lattice(env, LATTICE_ERROR_OUT_OF_MEMORY);
+            return 0;
+        }
+        while ((*env)->CallBooleanMethod(env, iter, hasNextM)) {
+            jobject item = (*env)->CallObjectMethod(env, iter, nextM);
+            if (list->len == cap) {
+                cap *= 2;
+                lattice_value *grown = (lattice_value *)
+                    realloc(list->items, cap * sizeof(lattice_value));
+                if (grown == NULL) {
+                    free_list(list);
+                    throw_lattice(env, LATTICE_ERROR_OUT_OF_MEMORY);
+                    return 0;
+                }
+                list->items = grown;
+            }
+            if (!fill_value(env, &list->items[list->len], item)) {
+                free_value_tree(&list->items[list->len]);
+                free_list(list);
+                return 0;
+            }
+            list->len++;
+            if (item != NULL) (*env)->DeleteLocalRef(env, item);
+        }
+        memset(dst, 0, sizeof(*dst));
+        dst->type = LATTICE_VALUE_LIST;
+        dst->data.list_val = list;
+        return 1;
+    }
+
+    /* java.util.Map -> MAP */
+    jclass mapCls = (*env)->FindClass(env, "java/util/Map");
+    if ((*env)->IsInstanceOf(env, value, mapCls)) {
+        jmethodID entrySetM = (*env)->GetMethodID(env, mapCls, "entrySet",
+                                                  "()Ljava/util/Set;");
+        jobject entrySet = (*env)->CallObjectMethod(env, value, entrySetM);
+        jclass setCls = (*env)->FindClass(env, "java/util/Set");
+        jmethodID iteratorM = (*env)->GetMethodID(env, setCls, "iterator",
+                                                  "()Ljava/util/Iterator;");
+        jclass iterCls = (*env)->FindClass(env, "java/util/Iterator");
+        jmethodID hasNextM = (*env)->GetMethodID(env, iterCls, "hasNext", "()Z");
+        jmethodID nextM = (*env)->GetMethodID(env, iterCls, "next", "()Ljava/lang/Object;");
+        jclass entryCls = (*env)->FindClass(env, "java/util/Map$Entry");
+        jmethodID getKeyM = (*env)->GetMethodID(env, entryCls, "getKey",
+                                                "()Ljava/lang/Object;");
+        jmethodID getValueM = (*env)->GetMethodID(env, entryCls, "getValue",
+                                                  "()Ljava/lang/Object;");
+        jobject iter = (*env)->CallObjectMethod(env, entrySet, iteratorM);
+
+        lattice_map *map = (lattice_map *)calloc(1, sizeof(lattice_map));
+        if (map == NULL) {
+            throw_lattice(env, LATTICE_ERROR_OUT_OF_MEMORY);
+            return 0;
+        }
+        size_t cap = 8, count = 0;
+        map->entries = (lattice_map_entry *)calloc(cap, sizeof(lattice_map_entry));
+        if (map->entries == NULL) {
+            free(map);
+            throw_lattice(env, LATTICE_ERROR_OUT_OF_MEMORY);
+            return 0;
+        }
+        while ((*env)->CallBooleanMethod(env, iter, hasNextM)) {
+            jobject entry = (*env)->CallObjectMethod(env, iter, nextM);
+            jobject key_obj = (*env)->CallObjectMethod(env, entry, getKeyM);
+            jobject val = (*env)->CallObjectMethod(env, entry, getValueM);
+            if (key_obj == NULL || !(*env)->IsInstanceOf(env, key_obj, CLS_STRING)) {
+                map->len = count;
+                free_map(map);
+                throw_lattice(env, LATTICE_ERROR_INVALID_ARG);
+                return 0;
+            }
+            jstring key = (jstring)key_obj;
+            if (count == cap) {
+                cap *= 2;
+                lattice_map_entry *grown = (lattice_map_entry *)
+                    realloc(map->entries, cap * sizeof(lattice_map_entry));
+                if (grown == NULL) {
+                    map->len = count;
+                    free_map(map);
+                    throw_lattice(env, LATTICE_ERROR_OUT_OF_MEMORY);
+                    return 0;
+                }
+                map->entries = grown;
+            }
+            size_t keyLen = 0;
+            char *keyBuf = jstring_to_utf8(env, key, &keyLen);
+            if (keyBuf == NULL) {
+                map->len = count;
+                free_map(map);
+                return 0;
+            }
+            map->entries[count].key = keyBuf;
+            map->entries[count].key_len = keyLen;
+            if (!fill_value(env, &map->entries[count].value, val)) {
+                free((void *)map->entries[count].key);
+                free_value_tree(&map->entries[count].value);
+                map->len = count;
+                free_map(map);
+                return 0;
+            }
+            count++;
+            if (entry) (*env)->DeleteLocalRef(env, entry);
+            (*env)->DeleteLocalRef(env, key_obj);
+            if (val) (*env)->DeleteLocalRef(env, val);
+        }
+        map->len = count;
+        memset(dst, 0, sizeof(*dst));
+        dst->type = LATTICE_VALUE_MAP;
+        dst->data.map_val = map;
+        return 1;
+    }
+
+    throw_lattice(env, LATTICE_ERROR_INVALID_ARG);
+    return 0;
+}
+
+/* Free a borrowed-call tree built by fill_value. */
+static void release_value_tree(lattice_value *v) {
+    free_value_tree(v);
+}
+
+/* ------------------------------------------------------------------ */
+/* Value conversion: lattice_value -> Java Object                      */
+/* ------------------------------------------------------------------ */
+
+static jobject value_to_java(JNIEnv *env, const lattice_value *v) {
+    switch (v->type) {
+        case LATTICE_VALUE_NULL:
+            return NULL;
+        case LATTICE_VALUE_BOOL:
+            return (*env)->NewObject(env, CLS_BOOL, MID_BOOL_INIT,
+                (jboolean)(v->data.bool_val ? JNI_TRUE : JNI_FALSE));
+        case LATTICE_VALUE_INT:
+            return (*env)->NewObject(env, CLS_LONG, MID_LONG_INIT,
+                (jlong)v->data.int_val);
+        case LATTICE_VALUE_FLOAT:
+            return (*env)->NewObject(env, CLS_DOUBLE, MID_DOUBLE_INIT,
+                (jdouble)v->data.float_val);
+        case LATTICE_VALUE_STRING:
+            return utf8_to_jstring(env, v->data.string_val.ptr, v->data.string_val.len);
+        case LATTICE_VALUE_BYTES: {
+            jsize len = (jsize)v->data.bytes_val.len;
+            jbyteArray arr = (*env)->NewByteArray(env, len);
+            if (arr == NULL) return NULL;
+            if (len > 0 && v->data.bytes_val.ptr != NULL) {
+                (*env)->SetByteArrayRegion(env, arr, 0, len,
+                                           (const jbyte *)v->data.bytes_val.ptr);
+            }
+            return arr;
+        }
+        case LATTICE_VALUE_VECTOR: {
+            jsize dims = (jsize)v->data.vector_val.dimensions;
+            jfloatArray arr = (*env)->NewFloatArray(env, dims);
+            if (arr == NULL) return NULL;
+            if (dims > 0 && v->data.vector_val.ptr != NULL) {
+                (*env)->SetFloatArrayRegion(env, arr, 0, dims, v->data.vector_val.ptr);
+            }
+            return arr;
+        }
+        case LATTICE_VALUE_LIST: {
+            lattice_list *list = v->data.list_val;
+            jobject out = (*env)->NewObject(env, CLS_ARRAYLIST, MID_ARRAYLIST_INIT,
+                                            (jint)(list ? list->len : 0));
+            if (out == NULL) return NULL;
+            if (list != NULL) {
+                for (size_t i = 0; i < list->len; i++) {
+                    jobject item = value_to_java(env, &list->items[i]);
+                    if (item != NULL) {
+                        (*env)->CallBooleanMethod(env, out, MID_ARRAYLIST_ADD, item);
+                        (*env)->DeleteLocalRef(env, item);
+                    } else {
+                        (*env)->CallBooleanMethod(env, out, MID_ARRAYLIST_ADD, NULL);
+                    }
+                }
+            }
+            return out;
+        }
+        case LATTICE_VALUE_MAP: {
+            lattice_map *map = v->data.map_val;
+            jobject out = (*env)->NewObject(env, CLS_LINKED_HASH_MAP, MID_LHM_INIT);
+            if (out == NULL) return NULL;
+            if (map != NULL) {
+                for (size_t i = 0; i < map->len; i++) {
+                    jstring key = utf8_to_jstring(env, map->entries[i].key,
+                                                  map->entries[i].key_len);
+                    jobject val = value_to_java(env, &map->entries[i].value);
+                    (*env)->CallObjectMethod(env, out, MID_LHM_PUT,
+                                             key ? (jobject)key : NULL,
+                                             val ? val : NULL);
+                    if (key) (*env)->DeleteLocalRef(env, key);
+                    if (val) (*env)->DeleteLocalRef(env, val);
+                }
+            }
+            return out;
+        }
+        default:
+            throw_lattice(env, LATTICE_ERROR_UNSUPPORTED);
+            return NULL;
+    }
+}
+
+/* Convert an owned lattice_value tree to Java and then free it. */
+static jobject take_owned_value(JNIEnv *env, lattice_value *v) {
+    jobject out = value_to_java(env, v);
+    lattice_value_free(v);
+    return out;
+}
+
+/* ------------------------------------------------------------------ */
+/* Database lifecycle                                                  */
+/* ------------------------------------------------------------------ */
+
+JNIEXPORT jstring JNICALL
+Java_io_latticedb_Native_version(JNIEnv *env, jclass cls) {
+    init_cache(env);
+    (void)cls;
+    return (*env)->NewStringUTF(env, lattice_version());
+}
+
+JNIEXPORT jlong JNICALL
+Java_io_latticedb_Native_open(JNIEnv *env, jclass cls, jstring path,
+        jboolean create, jboolean read_only, jint cache_size_mb, jint page_size,
+        jboolean enable_vector, jint vector_dimensions, jboolean enable_wal,
+        jboolean enable_adjacency_cache) {
+    init_cache(env);
+    (void)cls;
+    lattice_open_options_v3 opts;
+    memset(&opts, 0, sizeof(opts));
+    opts.struct_size = sizeof(opts);
+    opts.create = create == JNI_TRUE;
+    opts.read_only = read_only == JNI_TRUE;
+    opts.cache_size_mb = cache_size_mb <= 0 ? 100 : (uint32_t)cache_size_mb;
+    opts.page_size = page_size <= 0 ? 4096 : (uint32_t)page_size;
+    opts.enable_vector = enable_vector == JNI_TRUE;
+    opts.vector_dimensions = vector_dimensions <= 0 ? 128 : (uint16_t)vector_dimensions;
+    opts.enable_wal = enable_wal == JNI_TRUE;
+    opts.enable_adjacency_cache = enable_adjacency_cache == JNI_TRUE;
+
+    size_t path_len = 0;
+    char *path_buf = jstring_to_utf8(env, path, &path_len);
+    if (path_buf == NULL && (*env)->ExceptionCheck(env)) return 0;
+
+    lattice_database *db = NULL;
+    lattice_error rc = lattice_open_v3(path_buf, &opts, &db);
+    free(path_buf);
+    if (!check(env, rc)) return 0;
+    return (jlong)(uintptr_t)db;
+}
+
+JNIEXPORT void JNICALL
+Java_io_latticedb_Native_close(JNIEnv *env, jclass cls, jlong db_handle) {
+    init_cache(env);
+    (void)cls;
+    lattice_database *db = (lattice_database *)(uintptr_t)db_handle;
+    if (db == NULL) return;
+    check(env, lattice_close(db));
+}
+
+JNIEXPORT jlong JNICALL
+Java_io_latticedb_Native_begin(JNIEnv *env, jclass cls, jlong db_handle,
+                               jboolean read_only) {
+    init_cache(env);
+    (void)cls;
+    lattice_txn *txn = NULL;
+    lattice_error rc = lattice_begin((lattice_database *)(uintptr_t)db_handle,
+        read_only == JNI_TRUE ? LATTICE_TXN_READ_ONLY : LATTICE_TXN_READ_WRITE,
+        &txn);
+    if (!check(env, rc)) return 0;
+    return (jlong)(uintptr_t)txn;
+}
+
+JNIEXPORT void JNICALL
+Java_io_latticedb_Native_commit(JNIEnv *env, jclass cls, jlong txn_handle) {
+    init_cache(env);
+    (void)cls;
+    check(env, lattice_commit((lattice_txn *)(uintptr_t)txn_handle));
+}
+
+JNIEXPORT void JNICALL
+Java_io_latticedb_Native_rollback(JNIEnv *env, jclass cls, jlong txn_handle) {
+    init_cache(env);
+    (void)cls;
+    check(env, lattice_rollback((lattice_txn *)(uintptr_t)txn_handle));
+}
+
+/* ------------------------------------------------------------------ */
+/* Node operations                                                     */
+/* ------------------------------------------------------------------ */
+
+JNIEXPORT jlong JNICALL
+Java_io_latticedb_Native_nodeCreate(JNIEnv *env, jclass cls, jlong txn_handle,
+                                    jstring label) {
+    init_cache(env);
+    (void)cls;
+    size_t len = 0;
+    char *buf = label ? jstring_to_utf8(env, label, &len)
+                      : (char *)calloc(1, 1);
+    if ((*env)->ExceptionCheck(env)) { free(buf); return 0; }
+    lattice_node_id id = 0;
+    lattice_error rc = lattice_node_create((lattice_txn *)(uintptr_t)txn_handle,
+                                           buf ? buf : "", &id);
+    free(buf);
+    if (!check(env, rc)) return 0;
+    return (jlong)id;
+}
+
+JNIEXPORT void JNICALL
+Java_io_latticedb_Native_nodeAddLabel(JNIEnv *env, jclass cls, jlong txn_handle,
+                                      jlong node_id, jstring label) {
+    init_cache(env);
+    (void)cls;
+    char *buf = jstring_to_utf8(env, label, &(size_t){0});
+    if ((*env)->ExceptionCheck(env)) return;
+    lattice_error rc = lattice_node_add_label((lattice_txn *)(uintptr_t)txn_handle,
+                                              (lattice_node_id)node_id, buf);
+    free(buf);
+    check(env, rc);
+}
+
+JNIEXPORT void JNICALL
+Java_io_latticedb_Native_nodeRemoveLabel(JNIEnv *env, jclass cls, jlong txn_handle,
+                                         jlong node_id, jstring label) {
+    init_cache(env);
+    (void)cls;
+    char *buf = jstring_to_utf8(env, label, &(size_t){0});
+    if ((*env)->ExceptionCheck(env)) return;
+    lattice_error rc = lattice_node_remove_label((lattice_txn *)(uintptr_t)txn_handle,
+                                                 (lattice_node_id)node_id, buf);
+    free(buf);
+    check(env, rc);
+}
+
+JNIEXPORT void JNICALL
+Java_io_latticedb_Native_nodeDelete(JNIEnv *env, jclass cls, jlong txn_handle,
+                                    jlong node_id) {
+    init_cache(env);
+    (void)cls;
+    check(env, lattice_node_delete((lattice_txn *)(uintptr_t)txn_handle,
+                                   (lattice_node_id)node_id));
+}
+
+JNIEXPORT void JNICALL
+Java_io_latticedb_Native_nodeSetProperty(JNIEnv *env, jclass cls, jlong txn_handle,
+                                         jlong node_id, jstring key, jobject value) {
+    init_cache(env);
+    (void)cls;
+    lattice_value v;
+    if (!fill_value(env, &v, value)) return;
+    char *key_buf = key ? jstring_to_utf8(env, key, &(size_t){0}) : NULL;
+    if ((*env)->ExceptionCheck(env)) { release_value_tree(&v); return; }
+    lattice_error rc = lattice_node_set_property((lattice_txn *)(uintptr_t)txn_handle,
+        (lattice_node_id)node_id, key_buf, &v);
+    free(key_buf);
+    release_value_tree(&v);
+    check(env, rc);
+}
+
+JNIEXPORT jobject JNICALL
+Java_io_latticedb_Native_nodeGetProperty(JNIEnv *env, jclass cls, jlong txn_handle,
+                                         jlong node_id, jstring key) {
+    init_cache(env);
+    (void)cls;
+    char *key_buf = key ? jstring_to_utf8(env, key, &(size_t){0}) : NULL;
+    if ((*env)->ExceptionCheck(env)) return NULL;
+    lattice_value v;
+    memset(&v, 0, sizeof(v));
+    lattice_error rc = lattice_node_get_property((lattice_txn *)(uintptr_t)txn_handle,
+        (lattice_node_id)node_id, key_buf, &v);
+    free(key_buf);
+    if (rc == LATTICE_ERROR_NOT_FOUND) return NULL; /* missing key -> null */
+    if (!check(env, rc)) return NULL;
+    return take_owned_value(env, &v);
+}
+
+JNIEXPORT jboolean JNICALL
+Java_io_latticedb_Native_nodeExists(JNIEnv *env, jclass cls, jlong txn_handle,
+                                    jlong node_id) {
+    init_cache(env);
+    (void)cls;
+    bool exists = false;
+    lattice_error rc = lattice_node_exists((lattice_txn *)(uintptr_t)txn_handle,
+        (lattice_node_id)node_id, &exists);
+    if (!check(env, rc)) return JNI_FALSE;
+    return exists ? JNI_TRUE : JNI_FALSE;
+}
+
+JNIEXPORT jobjectArray JNICALL
+Java_io_latticedb_Native_nodeGetLabels(JNIEnv *env, jclass cls, jlong txn_handle,
+                                       jlong node_id) {
+    init_cache(env);
+    (void)cls;
+    char *joined = NULL;
+    lattice_error rc = lattice_node_get_labels((lattice_txn *)(uintptr_t)txn_handle,
+                                               (lattice_node_id)node_id, &joined);
+    if (!check(env, rc)) return NULL;
+    /* Labels come back comma-separated. Split on commas; labels themselves
+     * cannot contain commas in this engine (mirrors Go bridge behavior). */
+    jclass strCls = CLS_STRING;
+    jobjectArray arr;
+    size_t count = 0;
+    if (joined != NULL && joined[0] != '\0') {
+        count = 1;
+        for (const char *p = joined; *p; p++) if (*p == ',') count++;
+    }
+    arr = (*env)->NewObjectArray(env, (jsize)count, strCls, NULL);
+    size_t idx = 0;
+    char *cursor = joined;
+    while (cursor != NULL && idx < count) {
+        char *comma = strchr(cursor, ',');
+        size_t seg = comma ? (size_t)(comma - cursor) : strlen(cursor);
+        jstring s = utf8_to_jstring(env, cursor, seg);
+        (*env)->SetObjectArrayElement(env, arr, (jsize)idx++, s);
+        if (s) (*env)->DeleteLocalRef(env, s);
+        cursor = comma ? comma + 1 : NULL;
+    }
+    lattice_free_string(joined);
+    return arr;
+}
+
+JNIEXPORT jlongArray JNICALL
+Java_io_latticedb_Native_getNodesByLabelTxn(JNIEnv *env, jclass cls, jlong txn_handle,
+                                            jstring label) {
+    init_cache(env);
+    (void)cls;
+    size_t len = 0;
+    char *buf = jstring_to_utf8(env, label, &len);
+    if ((*env)->ExceptionCheck(env)) return NULL;
+    lattice_node_id *ids = NULL;
+    size_t count = 0;
+    lattice_error rc = lattice_get_nodes_by_label_txn(
+        (lattice_txn *)(uintptr_t)txn_handle, buf, buf ? len : 0, &ids, &count);
+    free(buf);
+    if (!check(env, rc)) return NULL;
+    jlongArray arr = (*env)->NewLongArray(env, (jsize)count);
+    if (arr != NULL && count > 0) {
+        (*env)->SetLongArrayRegion(env, arr, 0, (jsize)count, (const jlong *)ids);
+    }
+    lattice_free_node_ids(ids, count);
+    return arr;
+}
+
+JNIEXPORT jlongArray JNICALL
+Java_io_latticedb_Native_getAllNodesTxn(JNIEnv *env, jclass cls, jlong txn_handle) {
+    init_cache(env);
+    (void)cls;
+    lattice_node_id *ids = NULL;
+    size_t count = 0;
+    lattice_error rc = lattice_get_all_nodes_txn(
+        (lattice_txn *)(uintptr_t)txn_handle, &ids, &count);
+    if (!check(env, rc)) return NULL;
+    jlongArray arr = (*env)->NewLongArray(env, (jsize)count);
+    if (arr != NULL && count > 0) {
+        (*env)->SetLongArrayRegion(env, arr, 0, (jsize)count, (const jlong *)ids);
+    }
+    lattice_free_node_ids(ids, count);
+    return arr;
+}
+
+JNIEXPORT jlongArray JNICALL
+Java_io_latticedb_Native_getNodesByLabel(JNIEnv *env, jclass cls, jlong db_handle,
+                                         jstring label) {
+    init_cache(env);
+    (void)cls;
+    size_t len = 0;
+    char *buf = jstring_to_utf8(env, label, &len);
+    if ((*env)->ExceptionCheck(env)) return NULL;
+    lattice_node_id *ids = NULL;
+    size_t count = 0;
+    lattice_error rc = lattice_get_nodes_by_label(
+        (lattice_database *)(uintptr_t)db_handle, buf, buf ? len : 0, &ids, &count);
+    free(buf);
+    if (!check(env, rc)) return NULL;
+    jlongArray arr = (*env)->NewLongArray(env, (jsize)count);
+    if (arr != NULL && count > 0) {
+        (*env)->SetLongArrayRegion(env, arr, 0, (jsize)count, (const jlong *)ids);
+    }
+    lattice_free_node_ids(ids, count);
+    return arr;
+}
+
+JNIEXPORT void JNICALL
+Java_io_latticedb_Native_createNodePropertyIndex(JNIEnv *env, jclass cls,
+        jlong db_handle, jstring label, jstring property) {
+    init_cache(env);
+    (void)cls;
+    char *lb = jstring_to_utf8(env, label, &(size_t){0});
+    char *pb = jstring_to_utf8(env, property, &(size_t){0});
+    if ((*env)->ExceptionCheck(env)) { free(lb); free(pb); return; }
+    lattice_error rc = lattice_node_property_index_create(
+        (lattice_database *)(uintptr_t)db_handle, lb, pb);
+    free(lb); free(pb);
+    check(env, rc);
+}
+
+JNIEXPORT void JNICALL
+Java_io_latticedb_Native_dropNodePropertyIndex(JNIEnv *env, jclass cls,
+        jlong db_handle, jstring label, jstring property) {
+    init_cache(env);
+    (void)cls;
+    char *lb = jstring_to_utf8(env, label, &(size_t){0});
+    char *pb = jstring_to_utf8(env, property, &(size_t){0});
+    if ((*env)->ExceptionCheck(env)) { free(lb); free(pb); return; }
+    lattice_error rc = lattice_node_property_index_drop(
+        (lattice_database *)(uintptr_t)db_handle, lb, pb);
+    free(lb); free(pb);
+    check(env, rc);
+}
+
+JNIEXPORT jlongArray JNICALL
+Java_io_latticedb_Native_findNodesByLabelProperty(JNIEnv *env, jclass cls,
+        jlong txn_handle, jstring label, jstring property, jobject value, jint limit) {
+    init_cache(env);
+    (void)cls;
+    lattice_value v;
+    if (!fill_value(env, &v, value)) return NULL;
+    size_t lb_len = 0, pb_len = 0;
+    char *lb = jstring_to_utf8(env, label, &lb_len);
+    char *pb = jstring_to_utf8(env, property, &pb_len);
+    if ((*env)->ExceptionCheck(env)) {
+        release_value_tree(&v); free(lb); free(pb); return NULL;
+    }
+    lattice_node_id *ids = NULL;
+    size_t count = 0;
+    lattice_error rc = lattice_nodes_find_by_label_property(
+        (lattice_txn *)(uintptr_t)txn_handle, lb, pb, &v, (size_t)limit, &ids, &count);
+    release_value_tree(&v); free(lb); free(pb);
+    if (!check(env, rc)) return NULL;
+    jlongArray arr = (*env)->NewLongArray(env, (jsize)count);
+    if (arr != NULL && count > 0) {
+        (*env)->SetLongArrayRegion(env, arr, 0, (jsize)count, (const jlong *)ids);
+    }
+    lattice_free_node_ids(ids, count);
+    return arr;
+}
+
+JNIEXPORT void JNICALL
+Java_io_latticedb_Native_nodeSetVector(JNIEnv *env, jclass cls, jlong txn_handle,
+                                       jlong node_id, jstring key,
+                                       jfloatArray vector) {
+    init_cache(env);
+    (void)cls;
+    char *key_buf = key ? jstring_to_utf8(env, key, &(size_t){0}) : NULL;
+    if ((*env)->ExceptionCheck(env)) return;
+    jsize dims = vector ? (*env)->GetArrayLength(env, vector) : 0;
+    const float *ptr = NULL;
+    float *copy = NULL;
+    if (dims > 0) {
+        copy = (float *)malloc(sizeof(float) * (size_t)dims);
+        if (copy == NULL) { free(key_buf); throw_lattice(env, LATTICE_ERROR_OUT_OF_MEMORY); return; }
+        (*env)->GetFloatArrayRegion(env, vector, 0, dims, copy);
+        ptr = copy;
+    }
+    lattice_error rc = lattice_node_set_vector((lattice_txn *)(uintptr_t)txn_handle,
+        (lattice_node_id)node_id, key_buf, ptr, (uint32_t)dims);
+    free(copy);
+    free(key_buf);
+    check(env, rc);
+}
+
+/* ------------------------------------------------------------------ */
+/* Batch insert                                                        */
+/* ------------------------------------------------------------------ */
+
+JNIEXPORT jlongArray JNICALL
+Java_io_latticedb_Native_batchInsert(JNIEnv *env, jclass cls, jlong txn_handle,
+                                     jstring label, jobjectArray vectors) {
+    init_cache(env);
+    (void)cls;
+    size_t lb_len = 0;
+    char *lb = jstring_to_utf8(env, label, &lb_len);
+    if ((*env)->ExceptionCheck(env)) return NULL;
+    jsize count = (*env)->GetArrayLength(env, vectors);
+    lattice_node_with_vector *nodes = NULL;
+    float **copies = NULL;
+    if (count > 0) {
+        nodes = (lattice_node_with_vector *)calloc((size_t)count, sizeof(*nodes));
+        copies = (float **)calloc((size_t)count, sizeof(float *));
+        if (nodes == NULL || copies == NULL) {
+            free(nodes); free(copies); free(lb);
+            throw_lattice(env, LATTICE_ERROR_OUT_OF_MEMORY);
+            return NULL;
+        }
+        for (jsize i = 0; i < count; i++) {
+            nodes[i].label = lb;
+            jfloatArray vec = (jfloatArray)(*env)->GetObjectArrayElement(env, vectors, i);
+            jsize dims = vec ? (*env)->GetArrayLength(env, vec) : 0;
+            if (dims > 0 && vec != NULL) {
+                copies[i] = (float *)malloc(sizeof(float) * (size_t)dims);
+                if (copies[i] == NULL) {
+                    for (jsize j = 0; j < i; j++) free(copies[j]);
+                    free(copies); free(nodes); free(lb);
+                    throw_lattice(env, LATTICE_ERROR_OUT_OF_MEMORY);
+                    return NULL;
+                }
+                (*env)->GetFloatArrayRegion(env, vec, 0, dims, copies[i]);
+                nodes[i].vector = copies[i];
+                nodes[i].dimensions = (uint32_t)dims;
+            }
+            if (vec) (*env)->DeleteLocalRef(env, vec);
+        }
+    }
+    lattice_node_id *ids = (lattice_node_id *)
+        calloc(count > 0 ? (size_t)count : 1, sizeof(lattice_node_id));
+    uint32_t created = 0;
+    lattice_error rc = lattice_batch_insert((lattice_txn *)(uintptr_t)txn_handle,
+        nodes, (uint32_t)(count > 0 ? count : 0), ids, &created);
+    for (jsize i = 0; i < count; i++) free(copies ? copies[i] : NULL);
+    free(copies); free(nodes); free(lb);
+    if (!check(env, rc)) { free(ids); return NULL; }
+    jlongArray arr = (*env)->NewLongArray(env, (jsize)created);
+    if (arr != NULL && created > 0) {
+        (*env)->SetLongArrayRegion(env, arr, 0, (jsize)created, (const jlong *)ids);
+    }
+    free(ids);
+    return arr;
+}
+
+/* ------------------------------------------------------------------ */
+/* Edge operations                                                     */
+/* ------------------------------------------------------------------ */
+
+JNIEXPORT jlong JNICALL
+Java_io_latticedb_Native_edgeCreate(JNIEnv *env, jclass cls, jlong txn_handle,
+                                    jlong source, jlong target, jstring edge_type) {
+    init_cache(env);
+    (void)cls;
+    char *buf = edge_type ? jstring_to_utf8(env, edge_type, &(size_t){0})
+                          : (char *)calloc(1, 1);
+    if ((*env)->ExceptionCheck(env)) { free(buf); return 0; }
+    lattice_edge_id id = 0;
+    lattice_error rc = lattice_edge_create((lattice_txn *)(uintptr_t)txn_handle,
+        (lattice_node_id)source, (lattice_node_id)target, buf, &id);
+    free(buf);
+    if (!check(env, rc)) return 0;
+    return (jlong)id;
+}
+
+JNIEXPORT void JNICALL
+Java_io_latticedb_Native_edgeDelete(JNIEnv *env, jclass cls, jlong txn_handle,
+                                    jlong source, jlong target, jstring edge_type) {
+    init_cache(env);
+    (void)cls;
+    char *buf = edge_type ? jstring_to_utf8(env, edge_type, &(size_t){0}) : NULL;
+    if ((*env)->ExceptionCheck(env)) return;
+    lattice_error rc = lattice_edge_delete((lattice_txn *)(uintptr_t)txn_handle,
+        (lattice_node_id)source, (lattice_node_id)target, buf);
+    free(buf);
+    check(env, rc);
+}
+
+JNIEXPORT void JNICALL
+Java_io_latticedb_Native_edgeSetProperty(JNIEnv *env, jclass cls, jlong txn_handle,
+                                         jlong edge_id, jstring key, jobject value) {
+    init_cache(env);
+    (void)cls;
+    lattice_value v;
+    if (!fill_value(env, &v, value)) return;
+    char *key_buf = key ? jstring_to_utf8(env, key, &(size_t){0}) : NULL;
+    if ((*env)->ExceptionCheck(env)) { release_value_tree(&v); return; }
+    lattice_error rc = lattice_edge_set_property((lattice_txn *)(uintptr_t)txn_handle,
+        (lattice_edge_id)edge_id, key_buf, &v);
+    free(key_buf);
+    release_value_tree(&v);
+    check(env, rc);
+}
+
+JNIEXPORT jobject JNICALL
+Java_io_latticedb_Native_edgeGetProperty(JNIEnv *env, jclass cls, jlong txn_handle,
+                                         jlong edge_id, jstring key) {
+    init_cache(env);
+    (void)cls;
+    char *key_buf = key ? jstring_to_utf8(env, key, &(size_t){0}) : NULL;
+    if ((*env)->ExceptionCheck(env)) return NULL;
+    lattice_value v;
+    memset(&v, 0, sizeof(v));
+    lattice_error rc = lattice_edge_get_property((lattice_txn *)(uintptr_t)txn_handle,
+        (lattice_edge_id)edge_id, key_buf, &v);
+    free(key_buf);
+    if (rc == LATTICE_ERROR_NOT_FOUND) return NULL; /* missing key -> null */
+    if (!check(env, rc)) return NULL;
+    return take_owned_value(env, &v);
+}
+
+JNIEXPORT void JNICALL
+Java_io_latticedb_Native_edgeRemoveProperty(JNIEnv *env, jclass cls, jlong txn_handle,
+                                            jlong edge_id, jstring key) {
+    init_cache(env);
+    (void)cls;
+    char *key_buf = key ? jstring_to_utf8(env, key, &(size_t){0}) : NULL;
+    if ((*env)->ExceptionCheck(env)) return;
+    lattice_error rc = lattice_edge_remove_property((lattice_txn *)(uintptr_t)txn_handle,
+        (lattice_edge_id)edge_id, key_buf);
+    free(key_buf);
+    check(env, rc);
+}
+
+JNIEXPORT void JNICALL
+Java_io_latticedb_Native_createEdgePropertyIndex(JNIEnv *env, jclass cls,
+        jlong db_handle, jstring edge_type, jstring property) {
+    init_cache(env);
+    (void)cls;
+    char *tb = jstring_to_utf8(env, edge_type, &(size_t){0});
+    char *pb = jstring_to_utf8(env, property, &(size_t){0});
+    if ((*env)->ExceptionCheck(env)) { free(tb); free(pb); return; }
+    lattice_error rc = lattice_edge_property_index_create(
+        (lattice_database *)(uintptr_t)db_handle, tb, pb);
+    free(tb); free(pb);
+    check(env, rc);
+}
+
+JNIEXPORT void JNICALL
+Java_io_latticedb_Native_dropEdgePropertyIndex(JNIEnv *env, jclass cls,
+        jlong db_handle, jstring edge_type, jstring property) {
+    init_cache(env);
+    (void)cls;
+    char *tb = jstring_to_utf8(env, edge_type, &(size_t){0});
+    char *pb = jstring_to_utf8(env, property, &(size_t){0});
+    if ((*env)->ExceptionCheck(env)) { free(tb); free(pb); return; }
+    lattice_error rc = lattice_edge_property_index_drop(
+        (lattice_database *)(uintptr_t)db_handle, tb, pb);
+    free(tb); free(pb);
+    check(env, rc);
+}
+
+JNIEXPORT jlongArray JNICALL
+Java_io_latticedb_Native_findEdgesByTypeProperty(JNIEnv *env, jclass cls,
+        jlong txn_handle, jstring edge_type, jstring property, jobject value, jint limit) {
+    init_cache(env);
+    (void)cls;
+    lattice_value v;
+    if (!fill_value(env, &v, value)) return NULL;
+    size_t tb_len = 0, pb_len = 0;
+    char *tb = jstring_to_utf8(env, edge_type, &tb_len);
+    char *pb = jstring_to_utf8(env, property, &pb_len);
+    if ((*env)->ExceptionCheck(env)) {
+        release_value_tree(&v); free(tb); free(pb); return NULL;
+    }
+    lattice_edge_id *ids = NULL;
+    size_t count = 0;
+    lattice_error rc = lattice_edges_find_by_type_property(
+        (lattice_txn *)(uintptr_t)txn_handle, tb, pb, &v, (size_t)limit, &ids, &count);
+    release_value_tree(&v); free(tb); free(pb);
+    if (!check(env, rc)) return NULL;
+    jlongArray arr = (*env)->NewLongArray(env, (jsize)count);
+    if (arr != NULL && count > 0) {
+        (*env)->SetLongArrayRegion(env, arr, 0, (jsize)count, (const jlong *)ids);
+    }
+    lattice_free_edge_ids(ids, count);
+    return arr;
+}
+
+/* Fetch an edge result set. which: 0=outgoing,1=incoming,2=outgoing-by-type,
+ * 3=incoming-by-type,4=scan.
+ * Returns Object[2] = { long[] {id, source, target} * n, String[] types }. */
+static jobjectArray fetch_edges(JNIEnv *env, jlong txn_handle, jint which,
+                                jlong node_id, jstring edge_type, jint limit) {
+    char *type_buf = NULL;
+    if (which == 2 || which == 3 || which == 4) {
+        type_buf = edge_type ? jstring_to_utf8(env, edge_type, &(size_t){0}) : NULL;
+        if ((*env)->ExceptionCheck(env)) return NULL;
+    } else if (edge_type != NULL) {
+        type_buf = jstring_to_utf8(env, edge_type, &(size_t){0});
+        if ((*env)->ExceptionCheck(env)) return NULL;
+    }
+    lattice_txn *txn = (lattice_txn *)(uintptr_t)txn_handle;
+    lattice_edge_result *res = NULL;
+    lattice_error rc = LATTICE_OK;
+    switch (which) {
+        case 0: rc = lattice_edge_get_outgoing(txn, (lattice_node_id)node_id, &res); break;
+        case 1: rc = lattice_edge_get_incoming(txn, (lattice_node_id)node_id, &res); break;
+        case 2: rc = lattice_edge_get_outgoing_by_type(txn, (lattice_node_id)node_id,
+                    type_buf ? type_buf : "", (size_t)(limit < 0 ? 0 : limit), &res); break;
+        case 3: rc = lattice_edge_get_incoming_by_type(txn, (lattice_node_id)node_id,
+                    type_buf ? type_buf : "", (size_t)(limit < 0 ? 0 : limit), &res); break;
+        case 4: rc = lattice_edge_scan(txn, type_buf, (size_t)(limit < 0 ? 0 : limit), &res); break;
+        default: rc = LATTICE_ERROR_INVALID_ARG; break;
+    }
+    free(type_buf);
+    if (!check(env, rc)) return NULL;
+
+    uint32_t n = res ? lattice_edge_result_count(res) : 0;
+    jlong *triples = (jlong *)malloc(sizeof(jlong) * 3 * (n > 0 ? n : 1));
+    jobjectArray types = (*env)->NewObjectArray(env, (jsize)n, CLS_STRING, NULL);
+    if (triples == NULL || types == NULL) {
+        free(triples);
+        lattice_edge_result_free(res);
+        throw_lattice(env, LATTICE_ERROR_OUT_OF_MEMORY);
+        return NULL;
+    }
+    for (uint32_t i = 0; i < n; i++) {
+        lattice_node_id src = 0, tgt = 0;
+        lattice_edge_id eid = 0;
+        const char *type = NULL;
+        uint32_t type_len = 0;
+        lattice_edge_result_get_id(res, i, &eid);
+        lattice_edge_result_get(res, i, &src, &tgt, &type, &type_len);
+        triples[3 * i + 0] = (jlong)eid;
+        triples[3 * i + 1] = (jlong)src;
+        triples[3 * i + 2] = (jlong)tgt;
+        jstring jt = utf8_to_jstring(env, type, type_len);
+        (*env)->SetObjectArrayElement(env, types, (jsize)i, jt);
+        if (jt) (*env)->DeleteLocalRef(env, jt);
+    }
+    lattice_edge_result_free(res);
+
+    jlongArray idsArr = (*env)->NewLongArray(env, (jsize)(3 * n));
+    if (idsArr == NULL) {
+        free(triples);
+        throw_lattice(env, LATTICE_ERROR_OUT_OF_MEMORY);
+        return NULL;
+    }
+    if (n > 0) (*env)->SetLongArrayRegion(env, idsArr, 0, (jsize)(3 * n), triples);
+    free(triples);
+
+    jobjectArray out = (*env)->NewObjectArray(env, 2,
+        (*env)->FindClass(env, "java/lang/Object"), NULL);
+    if (out == NULL) return NULL;
+    (*env)->SetObjectArrayElement(env, out, 0, idsArr);
+    (*env)->SetObjectArrayElement(env, out, 1, types);
+    return out;
+}
+
+JNIEXPORT jobjectArray JNICALL
+Java_io_latticedb_Native_edgesOutgoing(JNIEnv *env, jclass cls, jlong txn_handle,
+                                       jlong node_id) {
+    init_cache(env); (void)cls;
+    return fetch_edges(env, txn_handle, 0, node_id, NULL, 0);
+}
+
+JNIEXPORT jobjectArray JNICALL
+Java_io_latticedb_Native_edgesIncoming(JNIEnv *env, jclass cls, jlong txn_handle,
+                                       jlong node_id) {
+    init_cache(env); (void)cls;
+    return fetch_edges(env, txn_handle, 1, node_id, NULL, 0);
+}
+
+JNIEXPORT jobjectArray JNICALL
+Java_io_latticedb_Native_edgesOutgoingByType(JNIEnv *env, jclass cls, jlong txn_handle,
+                                             jlong node_id, jstring edge_type, jint limit) {
+    init_cache(env); (void)cls;
+    return fetch_edges(env, txn_handle, 2, node_id, edge_type, limit);
+}
+
+JNIEXPORT jobjectArray JNICALL
+Java_io_latticedb_Native_edgesIncomingByType(JNIEnv *env, jclass cls, jlong txn_handle,
+                                             jlong node_id, jstring edge_type, jint limit) {
+    init_cache(env); (void)cls;
+    return fetch_edges(env, txn_handle, 3, node_id, edge_type, limit);
+}
+
+JNIEXPORT jobjectArray JNICALL
+Java_io_latticedb_Native_edgesScan(JNIEnv *env, jclass cls, jlong txn_handle,
+                                   jstring edge_type, jint limit) {
+    init_cache(env); (void)cls;
+    return fetch_edges(env, txn_handle, 4, 0, edge_type, limit);
+}
+
+/* ------------------------------------------------------------------ */
+/* Vector search                                                       */
+/* ------------------------------------------------------------------ */
+
+/* Returns Object[2] = { long[] nodeIds, float[] distances }.
+ * use_txn selects the txn/db variant. */
+static jobject search_vectors(JNIEnv *env, jlong db_handle, jlong txn_handle,
+                              jint use_txn, jfloatArray vector, jint k, jint ef_search) {
+    jsize dims = vector ? (*env)->GetArrayLength(env, vector) : 0;
+    float *copy = NULL;
+    if (dims > 0) {
+        copy = (float *)malloc(sizeof(float) * (size_t)dims);
+        if (copy == NULL) { throw_lattice(env, LATTICE_ERROR_OUT_OF_MEMORY); return NULL; }
+        (*env)->GetFloatArrayRegion(env, vector, 0, dims, copy);
+    }
+    lattice_vector_result *res = NULL;
+    lattice_error rc;
+    if (use_txn) {
+        rc = lattice_vector_search_txn((lattice_txn *)(uintptr_t)txn_handle,
+            copy, (uint32_t)dims, (uint32_t)k, (uint16_t)ef_search, &res);
+    } else {
+        rc = lattice_vector_search((lattice_database *)(uintptr_t)db_handle,
+            copy, (uint32_t)dims, (uint32_t)k, (uint16_t)ef_search, &res);
+    }
+    free(copy);
+    if (!check(env, rc)) return NULL;
+
+    uint32_t n = res ? lattice_vector_result_count(res) : 0;
+    jlong *ids = (jlong *)malloc(sizeof(jlong) * (n > 0 ? n : 1));
+    float *dists = (float *)malloc(sizeof(float) * (n > 0 ? n : 1));
+    if (ids == NULL || dists == NULL) {
+        free(ids); free(dists); lattice_vector_result_free(res);
+        throw_lattice(env, LATTICE_ERROR_OUT_OF_MEMORY);
+        return NULL;
+    }
+    for (uint32_t i = 0; i < n; i++) {
+        lattice_node_id id = 0;
+        float d = 0.0f;
+        lattice_vector_result_get(res, i, &id, &d);
+        ids[i] = (jlong)id;
+        dists[i] = d;
+    }
+    lattice_vector_result_free(res);
+
+    jlongArray idsArr = (*env)->NewLongArray(env, (jsize)n);
+    jfloatArray distsArr = (*env)->NewFloatArray(env, (jsize)n);
+    if (idsArr == NULL || distsArr == NULL) {
+        free(ids); free(dists);
+        throw_lattice(env, LATTICE_ERROR_OUT_OF_MEMORY);
+        return NULL;
+    }
+    if (n > 0) {
+        (*env)->SetLongArrayRegion(env, idsArr, 0, (jsize)n, ids);
+        (*env)->SetFloatArrayRegion(env, distsArr, 0, (jsize)n, dists);
+    }
+    free(ids); free(dists);
+    jobjectArray out = (*env)->NewObjectArray(env, 2,
+        (*env)->FindClass(env, "java/lang/Object"), NULL);
+    if (out == NULL) return NULL;
+    (*env)->SetObjectArrayElement(env, out, 0, idsArr);
+    (*env)->SetObjectArrayElement(env, out, 1, distsArr);
+    return out;
+}
+
+JNIEXPORT jobjectArray JNICALL
+Java_io_latticedb_Native_vectorSearch(JNIEnv *env, jclass cls, jlong db_handle,
+                                      jfloatArray vector, jint k, jint ef_search) {
+    init_cache(env); (void)cls;
+    return search_vectors(env, db_handle, 0, 0, vector, k, ef_search);
+}
+
+JNIEXPORT jobjectArray JNICALL
+Java_io_latticedb_Native_vectorSearchTxn(JNIEnv *env, jclass cls, jlong txn_handle,
+                                         jfloatArray vector, jint k, jint ef_search) {
+    init_cache(env); (void)cls;
+    return search_vectors(env, 0, txn_handle, 1, vector, k, ef_search);
+}
+
+/* ------------------------------------------------------------------ */
+/* Full-text search                                                    */
+/* ------------------------------------------------------------------ */
+
+JNIEXPORT void JNICALL
+Java_io_latticedb_Native_ftsIndex(JNIEnv *env, jclass cls, jlong txn_handle,
+                                  jlong node_id, jstring text) {
+    init_cache(env);
+    (void)cls;
+    size_t len = 0;
+    char *buf = text ? jstring_to_utf8(env, text, &len) : NULL;
+    if ((*env)->ExceptionCheck(env)) return;
+    lattice_error rc = lattice_fts_index((lattice_txn *)(uintptr_t)txn_handle,
+        (lattice_node_id)node_id, buf ? buf : "", len);
+    free(buf);
+    check(env, rc);
+}
+
+/* Returns Object[2] = { long[] nodeIds, float[] scores }. fuzzy=1 uses the
+ * fuzzy variant with max_distance/min_term_length. */
+static jobject fts_search(JNIEnv *env, jlong db_handle, jlong txn_handle, jint use_txn,
+                          jstring query, jint limit, jint fuzzy,
+                          jint max_distance, jint min_term_length) {
+    size_t qlen = 0;
+    char *q = query ? jstring_to_utf8(env, query, &qlen) : NULL;
+    if ((*env)->ExceptionCheck(env)) return NULL;
+    lattice_fts_result *res = NULL;
+    lattice_error rc;
+    if (fuzzy) {
+        if (use_txn) {
+            rc = lattice_fts_search_fuzzy_txn((lattice_txn *)(uintptr_t)txn_handle,
+                q ? q : "", qlen, (uint32_t)limit, (uint32_t)max_distance,
+                (uint32_t)min_term_length, &res);
+        } else {
+            rc = lattice_fts_search_fuzzy((lattice_database *)(uintptr_t)db_handle,
+                q ? q : "", qlen, (uint32_t)limit, (uint32_t)max_distance,
+                (uint32_t)min_term_length, &res);
+        }
+    } else {
+        if (use_txn) {
+            rc = lattice_fts_search_txn((lattice_txn *)(uintptr_t)txn_handle,
+                q ? q : "", qlen, (uint32_t)limit, &res);
+        } else {
+            rc = lattice_fts_search((lattice_database *)(uintptr_t)db_handle,
+                q ? q : "", qlen, (uint32_t)limit, &res);
+        }
+    }
+    free(q);
+    if (!check(env, rc)) return NULL;
+
+    uint32_t n = res ? lattice_fts_result_count(res) : 0;
+    jlong *ids = (jlong *)malloc(sizeof(jlong) * (n > 0 ? n : 1));
+    float *scores = (float *)malloc(sizeof(float) * (n > 0 ? n : 1));
+    if (ids == NULL || scores == NULL) {
+        free(ids); free(scores); lattice_fts_result_free(res);
+        throw_lattice(env, LATTICE_ERROR_OUT_OF_MEMORY);
+        return NULL;
+    }
+    for (uint32_t i = 0; i < n; i++) {
+        lattice_node_id id = 0;
+        float score = 0.0f;
+        lattice_fts_result_get(res, i, &id, &score);
+        ids[i] = (jlong)id;
+        scores[i] = score;
+    }
+    lattice_fts_result_free(res);
+
+    jlongArray idsArr = (*env)->NewLongArray(env, (jsize)n);
+    jfloatArray scoresArr = (*env)->NewFloatArray(env, (jsize)n);
+    if (idsArr == NULL || scoresArr == NULL) {
+        free(ids); free(scores);
+        throw_lattice(env, LATTICE_ERROR_OUT_OF_MEMORY);
+        return NULL;
+    }
+    if (n > 0) {
+        (*env)->SetLongArrayRegion(env, idsArr, 0, (jsize)n, ids);
+        (*env)->SetFloatArrayRegion(env, scoresArr, 0, (jsize)n, scores);
+    }
+    free(ids); free(scores);
+    jobjectArray out = (*env)->NewObjectArray(env, 2,
+        (*env)->FindClass(env, "java/lang/Object"), NULL);
+    if (out == NULL) return NULL;
+    (*env)->SetObjectArrayElement(env, out, 0, idsArr);
+    (*env)->SetObjectArrayElement(env, out, 1, scoresArr);
+    return out;
+}
+
+JNIEXPORT jobjectArray JNICALL
+Java_io_latticedb_Native_ftsSearch(JNIEnv *env, jclass cls, jlong db_handle,
+                                   jstring query, jint limit) {
+    init_cache(env); (void)cls;
+    return fts_search(env, db_handle, 0, 0, query, limit, 0, 0, 0);
+}
+
+JNIEXPORT jobjectArray JNICALL
+Java_io_latticedb_Native_ftsSearchFuzzy(JNIEnv *env, jclass cls, jlong db_handle,
+                                        jstring query, jint limit, jint max_distance,
+                                        jint min_term_length) {
+    init_cache(env); (void)cls;
+    return fts_search(env, db_handle, 0, 0, query, limit, 1, max_distance, min_term_length);
+}
+
+JNIEXPORT jobjectArray JNICALL
+Java_io_latticedb_Native_ftsSearchTxn(JNIEnv *env, jclass cls, jlong txn_handle,
+                                      jstring query, jint limit) {
+    init_cache(env); (void)cls;
+    return fts_search(env, 0, txn_handle, 1, query, limit, 0, 0, 0);
+}
+
+JNIEXPORT jobjectArray JNICALL
+Java_io_latticedb_Native_ftsSearchFuzzyTxn(JNIEnv *env, jclass cls, jlong txn_handle,
+                                           jstring query, jint limit, jint max_distance,
+                                           jint min_term_length) {
+    init_cache(env); (void)cls;
+    return fts_search(env, 0, txn_handle, 1, query, limit, 1, max_distance, min_term_length);
+}
+
+/* ------------------------------------------------------------------ */
+/* Streams                                                             */
+/* ------------------------------------------------------------------ */
+
+static int publish_stream_common(JNIEnv *env, jlong txn_handle, jstring stream,
+                                 jstring kind, jobject payload, jboolean want_seq,
+                                 jlong *seq_out) {
+    size_t s_len = 0, k_len = 0;
+    char *s = jstring_to_utf8(env, stream, &s_len);
+    char *k = kind ? jstring_to_utf8(env, kind, &k_len)
+                   : (char *)calloc(1, 1); /* empty -> default kind "message" */
+    lattice_value v;
+    int filled = fill_value(env, &v, payload);
+    if ((*env)->ExceptionCheck(env) || !filled) {
+        free(s); free(k); release_value_tree(&v);
+        return 0;
+    }
+    lattice_txn *txn = (lattice_txn *)(uintptr_t)txn_handle;
+    lattice_error rc;
+    if (want_seq == JNI_TRUE) {
+        uint64_t sequence = 0;
+        rc = lattice_stream_publish_get_sequence(txn, s, s_len, k, k ? k_len : 0, &v, &sequence);
+        if (rc == LATTICE_OK && seq_out != NULL) {
+            *seq_out = (jlong)sequence;
+        }
+    } else {
+        rc = lattice_stream_publish(txn, s, s_len, k, k ? k_len : 0, &v);
+    }
+    free(s); free(k);
+    release_value_tree(&v);
+    return check(env, rc);
+}
+
+JNIEXPORT void JNICALL
+Java_io_latticedb_Native_streamPublish(JNIEnv *env, jclass cls, jlong txn_handle,
+                                       jstring stream, jstring kind, jobject payload) {
+    init_cache(env); (void)cls;
+    publish_stream_common(env, txn_handle, stream, kind, payload, JNI_FALSE, NULL);
+}
+
+JNIEXPORT jlong JNICALL
+Java_io_latticedb_Native_streamPublishGetSequence(JNIEnv *env, jclass cls,
+        jlong txn_handle, jstring stream, jstring kind, jobject payload) {
+    init_cache(env); (void)cls;
+    jlong seq[1] = {0};
+    if (!publish_stream_common(env, txn_handle, stream, kind, payload, JNI_TRUE, seq))
+        return 0;
+    return seq[0];
+}
+
+/* Returns Object[3] = { long[] sequences, String[] kinds, Object[] payloads }. */
+JNIEXPORT jobjectArray JNICALL
+Java_io_latticedb_Native_streamRead(JNIEnv *env, jclass cls, jlong db_handle,
+                                    jstring stream, jlong after_sequence, jint limit,
+                                    jint timeout_ms) {
+    init_cache(env); (void)cls;
+    size_t s_len = 0;
+    char *s = jstring_to_utf8(env, stream, &s_len);
+    if ((*env)->ExceptionCheck(env)) return NULL;
+    lattice_stream_batch *batch = NULL;
+    lattice_error rc = lattice_stream_read((lattice_database *)(uintptr_t)db_handle,
+        s, s_len, (uint64_t)after_sequence, (size_t)(limit < 0 ? 0 : limit),
+        (uint32_t)timeout_ms, &batch);
+    free(s);
+    if (!check(env, rc)) return NULL;
+
+    size_t n = batch ? lattice_stream_batch_count(batch) : 0;
+    jlong *seqs = (jlong *)malloc(sizeof(jlong) * (n > 0 ? n : 1));
+    jobjectArray kinds = (*env)->NewObjectArray(env, (jsize)n, CLS_STRING, NULL);
+    jobjectArray payloads = (*env)->NewObjectArray(env, (jsize)n,
+        (*env)->FindClass(env, "java/lang/Object"), NULL);
+    if (seqs == NULL || kinds == NULL || payloads == NULL) {
+        free(seqs); lattice_stream_batch_free(batch);
+        throw_lattice(env, LATTICE_ERROR_OUT_OF_MEMORY);
+        return NULL;
+    }
+    for (size_t i = 0; i < n; i++) {
+        uint64_t seq = 0;
+        const char *kind = NULL;
+        size_t kind_len = 0;
+        const lattice_value *payload = NULL;
+        lattice_stream_batch_get(batch, i, &seq, &kind, &kind_len, &payload);
+        seqs[i] = (jlong)seq;
+        jstring jk = utf8_to_jstring(env, kind, kind_len);
+        (*env)->SetObjectArrayElement(env, kinds, (jsize)i, jk);
+        if (jk) (*env)->DeleteLocalRef(env, jk);
+        jobject jp = payload ? value_to_java(env, payload) : NULL;
+        (*env)->SetObjectArrayElement(env, payloads, (jsize)i, jp);
+        if (jp) (*env)->DeleteLocalRef(env, jp);
+    }
+    lattice_stream_batch_free(batch);
+
+    jlongArray seqsArr = (*env)->NewLongArray(env, (jsize)n);
+    if (seqsArr == NULL) {
+        free(seqs);
+        throw_lattice(env, LATTICE_ERROR_OUT_OF_MEMORY);
+        return NULL;
+    }
+    if (n > 0) (*env)->SetLongArrayRegion(env, seqsArr, 0, (jsize)n, seqs);
+    free(seqs);
+
+    jobjectArray out = (*env)->NewObjectArray(env, 3,
+        (*env)->FindClass(env, "java/lang/Object"), NULL);
+    if (out == NULL) return NULL;
+    (*env)->SetObjectArrayElement(env, out, 0, seqsArr);
+    (*env)->SetObjectArrayElement(env, out, 1, kinds);
+    (*env)->SetObjectArrayElement(env, out, 2, payloads);
+    return out;
+}
+
+/* Returns Object[2] = { Long offset or null when !exists, Boolean exists }. */
+JNIEXPORT jobjectArray JNICALL
+Java_io_latticedb_Native_streamGetOffset(JNIEnv *env, jclass cls, jlong db_handle,
+                                         jstring stream, jstring consumer) {
+    init_cache(env); (void)cls;
+    size_t s_len = 0, c_len = 0;
+    char *s = jstring_to_utf8(env, stream, &s_len);
+    char *c = consumer ? jstring_to_utf8(env, consumer, &c_len) : (char *)calloc(1, 1);
+    if ((*env)->ExceptionCheck(env)) { free(s); free(c); return NULL; }
+    bool offset_exists = false;
+    uint64_t sequence = 0;
+    lattice_error rc = lattice_stream_get_offset((lattice_database *)(uintptr_t)db_handle,
+        s, s_len, c, c ? c_len : 0, &offset_exists, &sequence);
+    free(s); free(c);
+    if (!check(env, rc)) return NULL;
+
+    jobjectArray out = (*env)->NewObjectArray(env, 2,
+        (*env)->FindClass(env, "java/lang/Object"), NULL);
+    if (out == NULL) return NULL;
+    jobject off = (*env)->NewObject(env, CLS_LONG, MID_LONG_INIT, (jlong)sequence);
+    jobject bex = (*env)->NewObject(env, CLS_BOOL, MID_BOOL_INIT,
+                                    offset_exists ? JNI_TRUE : JNI_FALSE);
+    (*env)->SetObjectArrayElement(env, out, 0, off);
+    (*env)->SetObjectArrayElement(env, out, 1, bex);
+    return out;
+}
+
+JNIEXPORT jlong JNICALL
+Java_io_latticedb_Native_streamGetLastSequence(JNIEnv *env, jclass cls,
+        jlong db_handle, jstring stream) {
+    init_cache(env); (void)cls;
+    size_t s_len = 0;
+    char *s = jstring_to_utf8(env, stream, &s_len);
+    if ((*env)->ExceptionCheck(env)) return 0;
+    uint64_t seq = 0;
+    lattice_error rc = lattice_stream_get_last_sequence(
+        (lattice_database *)(uintptr_t)db_handle, s, s_len, &seq);
+    free(s);
+    if (!check(env, rc)) return 0;
+    return (jlong)seq;
+}
+
+JNIEXPORT void JNICALL
+Java_io_latticedb_Native_streamSetOffset(JNIEnv *env, jclass cls, jlong txn_handle,
+                                         jstring stream, jstring consumer, jlong sequence) {
+    init_cache(env); (void)cls;
+    size_t s_len = 0, c_len = 0;
+    char *s = jstring_to_utf8(env, stream, &s_len);
+    char *c = consumer ? jstring_to_utf8(env, consumer, &c_len) : (char *)calloc(1, 1);
+    if ((*env)->ExceptionCheck(env)) { free(s); free(c); return; }
+    lattice_error rc = lattice_stream_set_offset((lattice_txn *)(uintptr_t)txn_handle,
+        s, s_len, c, c ? c_len : 0, (uint64_t)sequence);
+    free(s); free(c);
+    check(env, rc);
+}
+
+JNIEXPORT void JNICALL
+Java_io_latticedb_Native_streamTrim(JNIEnv *env, jclass cls, jlong txn_handle,
+                                    jstring stream, jlong through_sequence) {
+    init_cache(env); (void)cls;
+    size_t s_len = 0;
+    char *s = jstring_to_utf8(env, stream, &s_len);
+    if ((*env)->ExceptionCheck(env)) return;
+    lattice_error rc = lattice_stream_trim((lattice_txn *)(uintptr_t)txn_handle,
+        s, s_len, (uint64_t)through_sequence);
+    free(s);
+    check(env, rc);
+}
+
+/* ------------------------------------------------------------------ */
+/* Query engine                                                        */
+/* ------------------------------------------------------------------ */
+
+JNIEXPORT jlong JNICALL
+Java_io_latticedb_Native_queryPrepare(JNIEnv *env, jclass cls, jlong db_handle,
+                                      jstring cypher) {
+    init_cache(env); (void)cls;
+    size_t len = 0;
+    char *buf = jstring_to_utf8(env, cypher, &len);
+    if ((*env)->ExceptionCheck(env)) return 0;
+    lattice_query *q = NULL;
+    lattice_error rc = lattice_query_prepare((lattice_database *)(uintptr_t)db_handle,
+        buf ? buf : "", &q);
+    free(buf);
+    if (!check(env, rc)) return 0;
+    return (jlong)(uintptr_t)q;
+}
+
+JNIEXPORT void JNICALL
+Java_io_latticedb_Native_queryBind(JNIEnv *env, jclass cls, jlong query_handle,
+                                   jstring name, jobject value) {
+    init_cache(env); (void)cls;
+    lattice_value v;
+    if (!fill_value(env, &v, value)) return;
+    char *nb = name ? jstring_to_utf8(env, name, &(size_t){0}) : NULL;
+    if ((*env)->ExceptionCheck(env)) { release_value_tree(&v); return; }
+    lattice_error rc = lattice_query_bind((lattice_query *)(uintptr_t)query_handle,
+        nb ? nb : "", &v);
+    free(nb);
+    release_value_tree(&v);
+    check(env, rc);
+}
+
+JNIEXPORT void JNICALL
+Java_io_latticedb_Native_queryBindVector(JNIEnv *env, jclass cls, jlong query_handle,
+                                         jstring name, jfloatArray vector) {
+    init_cache(env); (void)cls;
+    char *nb = name ? jstring_to_utf8(env, name, &(size_t){0}) : NULL;
+    if ((*env)->ExceptionCheck(env)) return;
+    jsize dims = vector ? (*env)->GetArrayLength(env, vector) : 0;
+    float *copy = NULL;
+    if (dims > 0) {
+        copy = (float *)malloc(sizeof(float) * (size_t)dims);
+        if (copy == NULL) { free(nb); throw_lattice(env, LATTICE_ERROR_OUT_OF_MEMORY); return; }
+        (*env)->GetFloatArrayRegion(env, vector, 0, dims, copy);
+    }
+    lattice_error rc = lattice_query_bind_vector((lattice_query *)(uintptr_t)query_handle,
+        nb ? nb : "", copy, (uint32_t)dims);
+    free(copy);
+    free(nb);
+    check(env, rc);
+}
+
+JNIEXPORT jlong JNICALL
+Java_io_latticedb_Native_queryExecute(JNIEnv *env, jclass cls, jlong query_handle,
+                                      jlong txn_handle) {
+    init_cache(env); (void)cls;
+    lattice_result *result = NULL;
+    lattice_error rc = lattice_query_execute((lattice_query *)(uintptr_t)query_handle,
+        (lattice_txn *)(uintptr_t)txn_handle, &result);
+    if (rc != LATTICE_OK) {
+        throw_query_error(env, (lattice_query *)(uintptr_t)query_handle);
+        return 0;
+    }
+    return (jlong)(uintptr_t)result;
+}
+
+JNIEXPORT jboolean JNICALL
+Java_io_latticedb_Native_queryWrites(JNIEnv *env, jclass cls, jlong db_handle,
+                                     jstring cypher) {
+    init_cache(env); (void)cls;
+    /* Prepare a scratch query to ask whether it writes. */
+    size_t len = 0;
+    char *buf = jstring_to_utf8(env, cypher, &len);
+    if ((*env)->ExceptionCheck(env)) return JNI_FALSE;
+    lattice_query *q = NULL;
+    lattice_error rc = lattice_query_prepare((lattice_database *)(uintptr_t)db_handle,
+        buf ? buf : "", &q);
+    free(buf);
+    if (rc != LATTICE_OK || q == NULL) return JNI_FALSE; /* parse fails: weaker tx is fine */
+    jboolean writes = lattice_query_writes(q) ? JNI_TRUE : JNI_FALSE;
+    lattice_query_free(q);
+    return writes;
+}
+
+JNIEXPORT jboolean JNICALL
+Java_io_latticedb_Native_resultNext(JNIEnv *env, jclass cls, jlong result_handle) {
+    init_cache(env); (void)cls;
+    return lattice_result_next((lattice_result *)(uintptr_t)result_handle)
+               ? JNI_TRUE : JNI_FALSE;
+}
+
+JNIEXPORT jint JNICALL
+Java_io_latticedb_Native_resultColumnCount(JNIEnv *env, jclass cls, jlong result_handle) {
+    init_cache(env); (void)cls;
+    return (jint)lattice_result_column_count((lattice_result *)(uintptr_t)result_handle);
+}
+
+JNIEXPORT jstring JNICALL
+Java_io_latticedb_Native_resultColumnName(JNIEnv *env, jclass cls, jlong result_handle,
+                                          jint index) {
+    init_cache(env); (void)cls;
+    const char *name = lattice_result_column_name(
+        (lattice_result *)(uintptr_t)result_handle, (uint32_t)index);
+    return name ? (*env)->NewStringUTF(env, name) : NULL;
+}
+
+JNIEXPORT jobject JNICALL
+Java_io_latticedb_Native_resultGet(JNIEnv *env, jclass cls, jlong result_handle,
+                                   jint index) {
+    init_cache(env); (void)cls;
+    lattice_value v;
+    memset(&v, 0, sizeof(v));
+    lattice_error rc = lattice_result_get((lattice_result *)(uintptr_t)result_handle,
+        (uint32_t)index, &v);
+    if (!check(env, rc)) return NULL;
+    /* Borrowed from the result handle: convert only. */
+    jobject out = value_to_java(env, &v);
+    return out;
+}
+
+JNIEXPORT void JNICALL
+Java_io_latticedb_Native_resultFree(JNIEnv *env, jclass cls, jlong result_handle) {
+    init_cache(env); (void)cls;
+    if (result_handle == 0) return;
+    lattice_result_free((lattice_result *)(uintptr_t)result_handle);
+}
+
+JNIEXPORT void JNICALL
+Java_io_latticedb_Native_queryFree(JNIEnv *env, jclass cls, jlong query_handle) {
+    init_cache(env); (void)cls;
+    if (query_handle == 0) return;
+    lattice_query_free((lattice_query *)(uintptr_t)query_handle);
+}
+
+JNIEXPORT void JNICALL
+Java_io_latticedb_Native_cacheClear(JNIEnv *env, jclass cls, jlong db_handle) {
+    init_cache(env); (void)cls;
+    check(env, lattice_query_cache_clear((lattice_database *)(uintptr_t)db_handle));
+}
+
+/* Returns Object[3] = { Integer entries, Long hits, Long misses }. */
+JNIEXPORT jobjectArray JNICALL
+Java_io_latticedb_Native_cacheStats(JNIEnv *env, jclass cls, jlong db_handle) {
+    init_cache(env); (void)cls;
+    uint32_t entries = 0;
+    uint64_t hits = 0, misses = 0;
+    lattice_error rc = lattice_query_cache_stats(
+        (lattice_database *)(uintptr_t)db_handle, &entries, &hits, &misses);
+    if (!check(env, rc)) return NULL;
+    jobjectArray out = (*env)->NewObjectArray(env, 3,
+        (*env)->FindClass(env, "java/lang/Object"), NULL);
+    if (out == NULL) return NULL;
+    jobject e = (*env)->NewObject(env, CLS_INTEGER, MID_INT_INIT, (jint)entries);
+    jobject h = (*env)->NewObject(env, CLS_LONG, MID_LONG_INIT, (jlong)hits);
+    jobject m = (*env)->NewObject(env, CLS_LONG, MID_LONG_INIT, (jlong)misses);
+    (*env)->SetObjectArrayElement(env, out, 0, e);
+    (*env)->SetObjectArrayElement(env, out, 1, h);
+    (*env)->SetObjectArrayElement(env, out, 2, m);
+    return out;
+}
+
+/* ------------------------------------------------------------------ */
+/* Embedding helpers                                                   */
+/* ------------------------------------------------------------------ */
+
+JNIEXPORT jfloatArray JNICALL
+Java_io_latticedb_Native_hashEmbed(JNIEnv *env, jclass cls, jstring text,
+                                   jint dimensions) {
+    init_cache(env); (void)cls;
+    size_t len = 0;
+    char *buf = jstring_to_utf8(env, text, &len);
+    if ((*env)->ExceptionCheck(env)) return NULL;
+    float *vector = NULL;
+    uint32_t dims = 0;
+    lattice_error rc = lattice_hash_embed(buf ? buf : "", len,
+                                          (uint16_t)dimensions, &vector, &dims);
+    free(buf);
+    if (!check(env, rc)) return NULL;
+    jfloatArray arr = (*env)->NewFloatArray(env, (jsize)dims);
+    if (arr != NULL && dims > 0) {
+        (*env)->SetFloatArrayRegion(env, arr, 0, (jsize)dims, vector);
+    }
+    lattice_hash_embed_free(vector, dims);
+    return arr;
+}
+
+JNIEXPORT jlong JNICALL
+Java_io_latticedb_Native_embeddingClientCreate(JNIEnv *env, jclass cls,
+        jstring endpoint, jstring model, jint api_format, jstring api_key,
+        jint timeout_ms) {
+    init_cache(env); (void)cls;
+    lattice_embedding_config config;
+    memset(&config, 0, sizeof(config));
+    config.endpoint = NULL;
+    config.model = NULL;
+    config.api_format = (lattice_embedding_api_format)api_format;
+    config.api_key = NULL;
+    config.timeout_ms = (uint32_t)(timeout_ms <= 0 ? 0 : timeout_ms);
+
+    size_t dummy = 0;
+    char *ep = endpoint ? jstring_to_utf8(env, endpoint, &dummy) : NULL;
+    char *md = model ? jstring_to_utf8(env, model, &dummy) : NULL;
+    char *ak = api_key ? jstring_to_utf8(env, api_key, &dummy) : NULL;
+    if ((*env)->ExceptionCheck(env)) { free(ep); free(md); free(ak); return 0; }
+    config.endpoint = ep;
+    config.model = md;
+    config.api_key = ak;
+
+    lattice_embedding_client *client = NULL;
+    lattice_error rc = lattice_embedding_client_create(&config, &client);
+    free(ep); free(md); free(ak);
+    if (!check(env, rc)) return 0;
+    return (jlong)(uintptr_t)client;
+}
+
+JNIEXPORT jfloatArray JNICALL
+Java_io_latticedb_Native_embeddingClientEmbed(JNIEnv *env, jclass cls,
+        jlong client_handle, jstring text) {
+    init_cache(env); (void)cls;
+    size_t len = 0;
+    char *buf = jstring_to_utf8(env, text, &len);
+    if ((*env)->ExceptionCheck(env)) return NULL;
+    float *vector = NULL;
+    uint32_t dims = 0;
+    lattice_error rc = lattice_embedding_client_embed(
+        (lattice_embedding_client *)(uintptr_t)client_handle, buf ? buf : "", len,
+        &vector, &dims);
+    free(buf);
+    if (!check(env, rc)) return NULL;
+    jfloatArray arr = (*env)->NewFloatArray(env, (jsize)dims);
+    if (arr != NULL && dims > 0) {
+        (*env)->SetFloatArrayRegion(env, arr, 0, (jsize)dims, vector);
+    }
+    lattice_hash_embed_free(vector, dims);
+    return arr;
+}
+
+JNIEXPORT void JNICALL
+Java_io_latticedb_Native_embeddingClientFree(JNIEnv *env, jclass cls,
+                                             jlong client_handle) {
+    init_cache(env); (void)cls;
+    if (client_handle == 0) return;
+    lattice_embedding_client_free((lattice_embedding_client *)(uintptr_t)client_handle);
+}

--- a/bindings/java/pom.xml
+++ b/bindings/java/pom.xml
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.latticedb</groupId>
+  <artifactId>latticedb</artifactId>
+  <version>0.12.0</version>
+  <packaging>jar</packaging>
+
+  <name>LatticeDB Java Bindings</name>
+  <description>Java bindings for LatticeDB, an embedded property-graph database with native vector and full-text indexing.</description>
+
+  <properties>
+    <maven.compiler.release>21</maven.compiler.release>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <!-- Location of the native LatticeDB library (liblattice) produced by
+         `zig build` at the repository root. Override with -Dlattice.lib.dir=. -->
+    <lattice.lib.dir>${basedir}/../../zig-out/lib</lattice.lib.dir>
+    <native.output.dir>${project.build.directory}/native</native.output.dir>
+    <jni.include.os>linux</jni.include.os>
+    <native.library.extension>so</native.library.extension>
+    <native.rpath>$ORIGIN</native.rpath>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.10.2</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.13.0</version>
+      </plugin>
+
+      <!-- Compile the JNI bridge and stage it next to liblattice so the
+           platform-relative rpath resolves without environment variables. -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.2.0</version>
+        <executions>
+          <execution>
+            <id>create-native-output-directory</id>
+            <phase>process-classes</phase>
+            <goals><goal>exec</goal></goals>
+            <configuration>
+              <executable>mkdir</executable>
+              <arguments>
+                <argument>-p</argument>
+                <argument>${native.output.dir}</argument>
+              </arguments>
+            </configuration>
+          </execution>
+          <execution>
+            <id>build-native</id>
+            <phase>process-classes</phase>
+            <goals><goal>exec</goal></goals>
+            <configuration>
+              <executable>cc</executable>
+              <arguments>
+                <argument>-shared</argument>
+                <argument>-fPIC</argument>
+                <argument>-O2</argument>
+                <argument>-Wall</argument>
+                <argument>-I${java.home}/include</argument>
+                <argument>-I${java.home}/include/${jni.include.os}</argument>
+                <argument>-I../../include</argument>
+                <argument>-I${lattice.lib.dir}/../include</argument>
+                <argument>native/lattice_jni.c</argument>
+                <argument>-L${lattice.lib.dir}</argument>
+                <argument>-llattice</argument>
+                <argument>-Wl,-rpath,${native.rpath}</argument>
+                <argument>-o${native.output.dir}/liblattice_jni.${native.library.extension}</argument>
+              </arguments>
+            </configuration>
+          </execution>
+          <execution>
+            <id>run-example</id>
+            <goals><goal>java</goal></goals>
+            <configuration>
+              <mainClass>io.latticedb.examples.KnowledgeGraphExample</mainClass>
+              <systemProperties>
+                <systemProperty><key>latticedb.native.dir</key><value>${native.output.dir}</value></systemProperty>
+              </systemProperties>
+            </configuration>
+          </execution>
+          <execution>
+            <id>stage-native</id>
+            <phase>process-classes</phase>
+            <goals><goal>exec</goal></goals>
+            <configuration>
+              <executable>cp</executable>
+              <arguments>
+                <argument>${lattice.lib.dir}/liblattice.${native.library.extension}</argument>
+                <argument>${native.output.dir}/</argument>
+              </arguments>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.2.5</version>
+        <configuration>
+          <systemPropertyVariables>
+            <latticedb.native.dir>${native.output.dir}</latticedb.native.dir>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>macos-native</id>
+      <activation>
+        <os><family>mac</family></os>
+      </activation>
+      <properties>
+        <jni.include.os>darwin</jni.include.os>
+        <native.library.extension>dylib</native.library.extension>
+        <native.rpath>@loader_path</native.rpath>
+      </properties>
+    </profile>
+  </profiles>
+</project>

--- a/bindings/java/pom.xml
+++ b/bindings/java/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>io.latticedb</groupId>
   <artifactId>latticedb</artifactId>
-  <version>0.12.0</version>
+  <version>0.14.0</version>
   <packaging>jar</packaging>
 
   <name>LatticeDB Java Bindings</name>

--- a/bindings/java/src/main/java/io/latticedb/Database.java
+++ b/bindings/java/src/main/java/io/latticedb/Database.java
@@ -5,6 +5,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.OptionalLong;
+import java.util.Objects;
 
 /**
  * An open LatticeDB database.
@@ -44,8 +45,27 @@ public final class Database implements AutoCloseable {
         long handle = Native.open(path, options.create(), options.readOnly(),
                 options.cacheSizeMB(), options.pageSize(), options.enableVectors(),
                 options.vectorDimensions(), options.enableWal(),
-                options.enableAdjacencyCache());
+                options.enableAdjacencyCache(), options.lock());
         return new Database(path, options, handle);
+    }
+
+    /** Opens an in-memory database from bytes produced by {@link #serialize()}. */
+    public static Database deserialize(byte[] bytes) {
+        return deserialize(bytes, OpenOptions.defaults());
+    }
+
+    /**
+     * Opens an in-memory database from bytes produced by {@link #serialize()}.
+     * The bytes are copied, so the caller may reuse or discard them after this
+     * method returns. Changes do not affect the input array.
+     */
+    public static Database deserialize(byte[] bytes, OpenOptions options) {
+        Objects.requireNonNull(bytes, "bytes");
+        Objects.requireNonNull(options, "options");
+        long handle = Native.deserialize(bytes, options.cacheSizeMB(), options.pageSize(),
+                options.enableVectors(), options.vectorDimensions(), options.enableWal(),
+                options.enableAdjacencyCache(), options.lock());
+        return new Database("<deserialized>", options, handle);
     }
 
     public String getPath() {
@@ -77,6 +97,15 @@ public final class Database implements AutoCloseable {
             throw new LatticeException(ErrorCode.ERROR, "database is not open");
         }
         return h;
+    }
+
+    /**
+     * Returns the complete database file as bytes, including pending WAL data.
+     * Serialization fails with {@link ErrorCode#LOCK_TIMEOUT} while a
+     * transaction is open.
+     */
+    public byte[] serialize() {
+        return Native.serialize(handle());
     }
 
     /* ------------------------------------------------------------------ */

--- a/bindings/java/src/main/java/io/latticedb/Database.java
+++ b/bindings/java/src/main/java/io/latticedb/Database.java
@@ -66,7 +66,12 @@ public final class Database implements AutoCloseable {
         Native.close(h);
     }
 
-    long handle() {
+    // Synchronized against close(): without this, one thread can read a
+    // live handle while another closes and frees it, leaving the first
+    // with a stale jlong. The C API's handle registry turns a freed handle
+    // into err_invalid_arg rather than a crash, but address reuse could
+    // still route an operation to a different database.
+    synchronized long handle() {
         long h = handle;
         if (h == 0) {
             throw new LatticeException(ErrorCode.ERROR, "database is not open");

--- a/bindings/java/src/main/java/io/latticedb/Database.java
+++ b/bindings/java/src/main/java/io/latticedb/Database.java
@@ -1,0 +1,293 @@
+package io.latticedb;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.OptionalLong;
+
+/**
+ * An open LatticeDB database.
+ *
+ * <p>Instances own a native database handle; always close them (try-with-resources):
+ * <pre>{@code
+ * try (Database db = Database.open("knowledge.db", OpenOptions.defaults().create(true))) {
+ *     try (Transaction txn = db.beginWrite()) {
+ *         Node n = txn.createNode(List.of("Person"), Map.of("name", "Alice"));
+ *         txn.commit();
+ *     }
+ * }
+ * }</pre>
+ */
+public final class Database implements AutoCloseable {
+    private final String path;
+    private final OpenOptions options;
+    private long handle;
+
+    private Database(String path, OpenOptions options, long handle) {
+        this.path = path;
+        this.options = options;
+        this.handle = handle;
+    }
+
+    /** The engine version string. */
+    public static String version() {
+        return Native.version();
+    }
+
+    /** Opens (or creates) a database file with default options. */
+    public static Database open(String path) {
+        return open(path, OpenOptions.defaults());
+    }
+
+    public static Database open(String path, OpenOptions options) {
+        long handle = Native.open(path, options.create(), options.readOnly(),
+                options.cacheSizeMB(), options.pageSize(), options.enableVectors(),
+                options.vectorDimensions(), options.enableWal(),
+                options.enableAdjacencyCache());
+        return new Database(path, options, handle);
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public boolean isOpen() {
+        return handle != 0;
+    }
+
+    @Override
+    public synchronized void close() {
+        if (handle == 0) {
+            return;
+        }
+        long h = handle;
+        handle = 0;
+        Native.close(h);
+    }
+
+    long handle() {
+        long h = handle;
+        if (h == 0) {
+            throw new LatticeException(ErrorCode.ERROR, "database is not open");
+        }
+        return h;
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Transactions                                                        */
+    /* ------------------------------------------------------------------ */
+
+    /** Begins a read-only transaction. */
+    public Transaction beginRead() {
+        return new Transaction(this, true);
+    }
+
+    /** Begins a read-write transaction. At most one writer may be active. */
+    public Transaction beginWrite() {
+        if (options.readOnly()) {
+            throw new LatticeException(ErrorCode.READ_ONLY,
+                    "cannot write to a read-only database");
+        }
+        return new Transaction(this, false);
+    }
+
+    /** Runs {@code body} in an auto-managed read-only transaction (mirrors
+     * the Go binding's View). */
+    public <T> T read(java.util.function.Function<Transaction, T> body) {
+        try (Transaction txn = beginRead()) {
+            return body.apply(txn);
+        }
+    }
+
+    /**
+     * Runs {@code body} in a write transaction, committing on success and
+     * rolling back on exception (mirrors the Go binding's Update).
+     */
+    public <T> T write(java.util.function.Function<Transaction, T> body) {
+        try (Transaction txn = beginWrite()) {
+            T result = body.apply(txn);
+            txn.commit();
+            return result;
+        }
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Query                                                               */
+    /* ------------------------------------------------------------------ */
+
+    /**
+     * Executes a Cypher query with auto-managed transaction mode: write
+     * queries run in a write transaction, everything else in a read
+     * transaction (mirrors DB.Query in the Go binding).
+     */
+    public QueryResult query(String cypher, Map<String, Object> parameters) {
+        if (!isOpen()) {
+            throw new LatticeException(ErrorCode.ERROR, "database is not open");
+        }
+        boolean writes = !options.readOnly() && Native.queryWrites(handle(), cypher);
+        if (writes) {
+            try (Transaction txn = beginWrite()) {
+                QueryResult result = txn.query(cypher, parameters);
+                txn.commit();
+                return result;
+            }
+        }
+        try (Transaction txn = beginRead()) {
+            return txn.query(cypher, parameters);
+        }
+    }
+
+    public QueryResult query(String cypher) {
+        return query(cypher, Map.of());
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Search                                                              */
+    /* ------------------------------------------------------------------ */
+
+    public List<VectorSearchResult> vectorSearch(float[] vector, VectorSearchOptions opts) {
+        int k = opts == null ? 10 : opts.k();
+        int ef = opts == null ? 0 : opts.efSearch();
+        Object[] out = Native.vectorSearch(handle(), vector, k, ef);
+        return zipVectorResults(out);
+    }
+
+    public List<FTSSearchResult> ftsSearch(String query, FTSSearchOptions opts) {
+        int limit = opts == null ? 10 : opts.limit();
+        Object[] out = Native.ftsSearch(handle(), query, limit);
+        return zipFtsResults(out);
+    }
+
+    public List<FTSSearchResult> ftsSearchFuzzy(String query, FTSSearchOptions opts) {
+        int limit = opts == null ? 10 : opts.limit();
+        int maxDistance = opts == null ? 0 : opts.maxDistance();
+        int minTermLength = opts == null ? 0 : opts.minTermLength();
+        Object[] out = Native.ftsSearchFuzzy(handle(), query, limit,
+                maxDistance, minTermLength);
+        return zipFtsResults(out);
+    }
+
+    static List<VectorSearchResult> zipVectorResults(Object[] out) {
+        long[] ids = (long[]) out[0];
+        float[] dists = (float[]) out[1];
+        List<VectorSearchResult> results = new ArrayList<>(ids.length);
+        for (int i = 0; i < ids.length; i++) {
+            results.add(new VectorSearchResult(ids[i], dists[i]));
+        }
+        return results;
+    }
+
+    static List<FTSSearchResult> zipFtsResults(Object[] out) {
+        long[] ids = (long[]) out[0];
+        float[] scores = (float[]) out[1];
+        List<FTSSearchResult> results = new ArrayList<>(ids.length);
+        for (int i = 0; i < ids.length; i++) {
+            results.add(new FTSSearchResult(ids[i], scores[i]));
+        }
+        return results;
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Schema / labels                                                     */
+    /* ------------------------------------------------------------------ */
+
+    /** Creates an explicit equality index for a node label/property pair. */
+    public void createNodePropertyIndex(String label, String property) {
+        Native.createNodePropertyIndex(handle(), label, property);
+    }
+
+    public void dropNodePropertyIndex(String label, String property) {
+        Native.dropNodePropertyIndex(handle(), label, property);
+    }
+
+    /** Creates an explicit equality index for an edge type/property pair. */
+    public void createEdgePropertyIndex(String edgeType, String property) {
+        Native.createEdgePropertyIndex(handle(), edgeType, property);
+    }
+
+    public void dropEdgePropertyIndex(String edgeType, String property) {
+        Native.dropEdgePropertyIndex(handle(), edgeType, property);
+    }
+
+    /**
+     * Returns every node id carrying the given label. Unknown labels yield
+     * an empty list.
+     */
+    public List<Long> getNodesByLabel(String label) {
+        return toIdList(Native.getNodesByLabel(handle(), label));
+    }
+
+    static List<Long> toIdList(long[] ids) {
+        List<Long> out = new ArrayList<>(ids.length);
+        for (long id : ids) {
+            out.add(id);
+        }
+        return out;
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Streams                                                             */
+    /* ------------------------------------------------------------------ */
+
+    /**
+     * Reads records after a sequence cursor without committing offsets. If no
+     * records are available, waits up to {@code timeoutMs} for a same-process
+     * commit wakeup.
+     */
+    public List<StreamRecord> readStream(String stream, long afterSequence,
+                                         int limit, int timeoutMs) {
+        Object[] out = Native.streamRead(handle(), stream, afterSequence, limit, timeoutMs);
+        long[] seqs = (long[]) out[0];
+        String[] kinds = (String[]) out[1];
+        Object[] payloads = (Object[]) out[2];
+        List<StreamRecord> records = new ArrayList<>(seqs.length);
+        for (int i = 0; i < seqs.length; i++) {
+            records.add(new StreamRecord(seqs[i], kinds[i], payloads[i]));
+        }
+        return records;
+    }
+
+    /** Consumer offset for a stream, empty when the consumer has none. */
+    public OptionalLong getStreamOffset(String stream, String consumer) {
+        Object[] out = Native.streamGetOffset(handle(), stream, consumer);
+        boolean exists = (Boolean) out[1];
+        if (!exists) {
+            return OptionalLong.empty();
+        }
+        return OptionalLong.of((Long) out[0]);
+    }
+
+    /** Latest sequence published to a stream, or 0 when it has no records. */
+    public long getLastSequence(String stream) {
+        return Native.streamGetLastSequence(handle(), stream);
+    }
+
+    /** Reads the built-in graph changefeed. */
+    public List<StreamRecord> changes(long afterSequence, int limit, int timeoutMs) {
+        return readStream("__lattice_changes", afterSequence, limit, timeoutMs);
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Query cache                                                         */
+    /* ------------------------------------------------------------------ */
+
+    public void cacheClear() {
+        Native.cacheClear(handle());
+    }
+
+    public QueryCacheStats cacheStats() {
+        Object[] out = Native.cacheStats(handle());
+        return new QueryCacheStats((Integer) out[0], (Long) out[1], (Long) out[2]);
+    }
+
+    @Override
+    public String toString() {
+        return "Database[path=" + path + ", open=" + isOpen() + "]";
+    }
+
+    /** Suppress unused-import warning helper used by query row building. */
+    static Map<String, Object> newRow() {
+        return new LinkedHashMap<>();
+    }
+}

--- a/bindings/java/src/main/java/io/latticedb/Edge.java
+++ b/bindings/java/src/main/java/io/latticedb/Edge.java
@@ -1,0 +1,20 @@
+package io.latticedb;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * A graph edge returned by transaction operations.
+ *
+ * @param id         stable edge id
+ * @param sourceId   source node id
+ * @param targetId   target node id
+ * @param type       edge type
+ * @param properties property map
+ */
+public record Edge(long id, long sourceId, long targetId, String type,
+                   Map<String, Object> properties) {
+    public Edge {
+        properties = properties == null ? Map.of() : Collections.unmodifiableMap(properties);
+    }
+}

--- a/bindings/java/src/main/java/io/latticedb/Embedding.java
+++ b/bindings/java/src/main/java/io/latticedb/Embedding.java
@@ -1,0 +1,80 @@
+package io.latticedb;
+
+/**
+ * Embedding helpers: the built-in deterministic hash embedding plus an HTTP
+ * embedding client backed by native code (mirrors the Go binding's embedding
+ * package).
+ */
+public final class Embedding {
+    /** API wire format for {@link Client}. */
+    public enum APIFormat {
+        OLLAMA(0),
+        OPENAI(1);
+
+        private final int value;
+
+        APIFormat(int value) {
+            this.value = value;
+        }
+
+        int value() {
+            return value;
+        }
+    }
+
+    /** Configuration for {@link Client}. */
+    public record Config(String endpoint, String model, APIFormat apiFormat,
+                         String apiKey, int timeoutMs) {
+        public Config {
+            if (apiFormat == null) {
+                apiFormat = APIFormat.OLLAMA;
+            }
+            if (timeoutMs <= 0) {
+                timeoutMs = 0; /* engine default: 30s */
+            }
+        }
+    }
+
+    private Embedding() {
+    }
+
+    /**
+     * Generates a deterministic placeholder embedding with no external
+     * service. Similar text does NOT produce nearby vectors; use a real
+     * model for meaningful similarity.
+     */
+    public static float[] hashEmbed(String text, int dimensions) {
+        return Native.hashEmbed(text, dimensions);
+    }
+
+    /** HTTP embedding client. Close when done. */
+    public static final class Client implements AutoCloseable {
+        private long handle;
+
+        private Client(long handle) {
+            this.handle = handle;
+        }
+
+        public static Client open(Config config) {
+            return new Client(Native.embeddingClientCreate(config.endpoint(),
+                    config.model(), config.apiFormat().value(), config.apiKey(),
+                    config.timeoutMs()));
+        }
+
+        public synchronized float[] embed(String text) {
+            if (handle == 0) {
+                throw new LatticeException(ErrorCode.ERROR, "embedding client is closed");
+            }
+            return Native.embeddingClientEmbed(handle, text);
+        }
+
+        @Override
+        public synchronized void close() {
+            if (handle == 0) {
+                return;
+            }
+            Native.embeddingClientFree(handle);
+            handle = 0;
+        }
+    }
+}

--- a/bindings/java/src/main/java/io/latticedb/ErrorCode.java
+++ b/bindings/java/src/main/java/io/latticedb/ErrorCode.java
@@ -21,7 +21,7 @@ public enum ErrorCode {
     /** Another process holds the database file (native code -16, added in
      * 0.13.0). Distinct from {@link #LOCK_TIMEOUT}, which reports a second
      * writer inside this process. */
-    FILE_LOCKED(-16),
+    DATABASE_LOCKED(-16),
     /** Placeholder for native codes this binding does not recognize. The
      * original numeric code is preserved on the exception that carries it
      * (see {@link LatticeException#getNativeCode()}). */

--- a/bindings/java/src/main/java/io/latticedb/ErrorCode.java
+++ b/bindings/java/src/main/java/io/latticedb/ErrorCode.java
@@ -17,7 +17,15 @@ public enum ErrorCode {
     CHECKSUM(-12),
     OUT_OF_MEMORY(-13),
     UNSUPPORTED(-14),
-    VALUE_TOO_LARGE(-15);
+    VALUE_TOO_LARGE(-15),
+    /** Another process holds the database file (native code -16, added in
+     * 0.13.0). Distinct from {@link #LOCK_TIMEOUT}, which reports a second
+     * writer inside this process. */
+    FILE_LOCKED(-16),
+    /** Placeholder for native codes this binding does not recognize. The
+     * original numeric code is preserved on the exception that carries it
+     * (see {@link LatticeException#getNativeCode()}). */
+    UNKNOWN(-9999);
 
     private final int code;
 
@@ -32,10 +40,13 @@ public enum ErrorCode {
 
     static ErrorCode fromCode(int code) {
         for (ErrorCode ec : values()) {
-            if (ec.code == code) {
+            if (ec.code == code && ec != UNKNOWN) {
                 return ec;
             }
         }
-        throw new IllegalArgumentException("unknown error code: " + code);
+        // Fall back to a catch-all so the caller still gets as much
+        // diagnostic info as possible; the raw numeric code is kept on the
+        // exception via LatticeException.getNativeCode().
+        return UNKNOWN;
     }
 }

--- a/bindings/java/src/main/java/io/latticedb/ErrorCode.java
+++ b/bindings/java/src/main/java/io/latticedb/ErrorCode.java
@@ -1,0 +1,41 @@
+package io.latticedb;
+
+/** Error codes mirroring {@code lattice_error} from the native C API. */
+public enum ErrorCode {
+    OK(0),
+    ERROR(-1),
+    IO(-2),
+    CORRUPTION(-3),
+    NOT_FOUND(-4),
+    ALREADY_EXISTS(-5),
+    INVALID_ARG(-6),
+    TXN_ABORTED(-7),
+    LOCK_TIMEOUT(-8),
+    READ_ONLY(-9),
+    FULL(-10),
+    VERSION_MISMATCH(-11),
+    CHECKSUM(-12),
+    OUT_OF_MEMORY(-13),
+    UNSUPPORTED(-14),
+    VALUE_TOO_LARGE(-15);
+
+    private final int code;
+
+    ErrorCode(int code) {
+        this.code = code;
+    }
+
+    /** The native {@code lattice_error} value. */
+    public int code() {
+        return code;
+    }
+
+    static ErrorCode fromCode(int code) {
+        for (ErrorCode ec : values()) {
+            if (ec.code == code) {
+                return ec;
+            }
+        }
+        throw new IllegalArgumentException("unknown error code: " + code);
+    }
+}

--- a/bindings/java/src/main/java/io/latticedb/FTSSearchOptions.java
+++ b/bindings/java/src/main/java/io/latticedb/FTSSearchOptions.java
@@ -1,0 +1,37 @@
+package io.latticedb;
+
+/** Options for full-text search methods. */
+public final class FTSSearchOptions {
+    private int limit = 10;
+    private int maxDistance = 0;      /* 0 = engine default (2) */
+    private int minTermLength = 0;    /* 0 = engine default (4) */
+
+    private FTSSearchOptions() {
+    }
+
+    public static FTSSearchOptions defaults() {
+        return new FTSSearchOptions();
+    }
+
+    /** Maximum number of results. Default 10. */
+    public FTSSearchOptions limit(int limit) {
+        this.limit = limit;
+        return this;
+    }
+
+    /** Max Levenshtein edit distance for fuzzy search; 0 = default 2. */
+    public FTSSearchOptions maxDistance(int maxDistance) {
+        this.maxDistance = maxDistance;
+        return this;
+    }
+
+    /** Min term length for fuzzy expansion; 0 = default 4. */
+    public FTSSearchOptions minTermLength(int minTermLength) {
+        this.minTermLength = minTermLength;
+        return this;
+    }
+
+    int limit() { return limit; }
+    int maxDistance() { return maxDistance; }
+    int minTermLength() { return minTermLength; }
+}

--- a/bindings/java/src/main/java/io/latticedb/FTSSearchResult.java
+++ b/bindings/java/src/main/java/io/latticedb/FTSSearchResult.java
@@ -1,0 +1,5 @@
+package io.latticedb;
+
+/** One full-text search hit (BM25-scored). */
+public record FTSSearchResult(long nodeId, float score) {
+}

--- a/bindings/java/src/main/java/io/latticedb/LatticeException.java
+++ b/bindings/java/src/main/java/io/latticedb/LatticeException.java
@@ -1,0 +1,23 @@
+package io.latticedb;
+
+/**
+ * Runtime exception carrying a native {@code lattice_error} code.
+ *
+ * Thrown by all LatticeDB operations that fail at the native layer.
+ */
+public class LatticeException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public LatticeException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    LatticeException(int rawCode, String message) {
+        this(ErrorCode.fromCode(rawCode), message);
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/bindings/java/src/main/java/io/latticedb/LatticeException.java
+++ b/bindings/java/src/main/java/io/latticedb/LatticeException.java
@@ -7,17 +7,33 @@ package io.latticedb;
  */
 public class LatticeException extends RuntimeException {
     private final ErrorCode errorCode;
+    private final int nativeCode;
 
     public LatticeException(ErrorCode errorCode, String message) {
+        this(errorCode, errorCode.code(), message);
+    }
+
+    LatticeException(ErrorCode errorCode, int nativeCode, String message) {
         super(message);
         this.errorCode = errorCode;
+        this.nativeCode = nativeCode;
     }
 
     LatticeException(int rawCode, String message) {
-        this(ErrorCode.fromCode(rawCode), message);
+        this(ErrorCode.fromCode(rawCode), rawCode,
+                ErrorCode.fromCode(rawCode) == ErrorCode.UNKNOWN
+                        ? message + " (native error code " + rawCode + ")"
+                        : message);
     }
 
     public ErrorCode getErrorCode() {
         return errorCode;
+    }
+
+    /** The raw numeric {@code lattice_error} value behind this failure.
+     * For unrecognized codes this preserves diagnostics that the enum
+     * cannot express. */
+    public int getNativeCode() {
+        return nativeCode;
     }
 }

--- a/bindings/java/src/main/java/io/latticedb/Native.java
+++ b/bindings/java/src/main/java/io/latticedb/Native.java
@@ -1,0 +1,172 @@
+package io.latticedb;
+
+/**
+ * Native entry points. Package-private: all native methods live here so JNI
+ * symbol names stay uniform and the public API classes remain free of
+ * {@code native} declarations.
+ */
+final class Native {
+    private Native() {
+    }
+
+    static {
+        NativeLoader.load();
+    }
+
+    /* Database lifecycle */
+    static native String version();
+
+    static native long open(String path, boolean create, boolean readOnly,
+                            int cacheSizeMB, int pageSize, boolean enableVector,
+                            int vectorDimensions, boolean enableWal,
+                            boolean enableAdjacencyCache);
+
+    static native void close(long db);
+
+    static native long begin(long db, boolean readOnly);
+
+    static native void commit(long txn);
+
+    static native void rollback(long txn);
+
+    /* Nodes */
+    static native long nodeCreate(long txn, String label);
+
+    static native void nodeAddLabel(long txn, long nodeId, String label);
+
+    static native void nodeRemoveLabel(long txn, long nodeId, String label);
+
+    static native void nodeDelete(long txn, long nodeId);
+
+    static native void nodeSetProperty(long txn, long nodeId, String key, Object value);
+
+    static native Object nodeGetProperty(long txn, long nodeId, String key);
+
+    static native boolean nodeExists(long txn, long nodeId);
+
+    static native String[] nodeGetLabels(long txn, long nodeId);
+
+    static native long[] getNodesByLabelTxn(long txn, String label);
+
+    static native long[] getAllNodesTxn(long txn);
+
+    static native long[] getNodesByLabel(long db, String label);
+
+    static native void createNodePropertyIndex(long db, String label, String property);
+
+    static native void dropNodePropertyIndex(long db, String label, String property);
+
+    static native long[] findNodesByLabelProperty(long txn, String label,
+                                                  String property, Object value, int limit);
+
+    static native void nodeSetVector(long txn, long nodeId, String key, float[] vector);
+
+    static native long[] batchInsert(long txn, String label, float[][] vectors);
+
+    /* Edges */
+    static native long edgeCreate(long txn, long source, long target, String edgeType);
+
+    static native void edgeDelete(long txn, long source, long target, String edgeType);
+
+    static native void edgeSetProperty(long txn, long edgeId, String key, Object value);
+
+    static native Object edgeGetProperty(long txn, long edgeId, String key);
+
+    static native void edgeRemoveProperty(long txn, long edgeId, String key);
+
+    static native void createEdgePropertyIndex(long db, String edgeType, String property);
+
+    static native void dropEdgePropertyIndex(long db, String edgeType, String property);
+
+    static native long[] findEdgesByTypeProperty(long txn, String edgeType,
+                                                 String property, Object value, int limit);
+
+    /** Returns Object[2]: long[]{id,source,target}*n and String[] types. */
+    static native Object[] edgesOutgoing(long txn, long nodeId);
+
+    static native Object[] edgesIncoming(long txn, long nodeId);
+
+    static native Object[] edgesOutgoingByType(long txn, long nodeId, String edgeType, int limit);
+
+    static native Object[] edgesIncomingByType(long txn, long nodeId, String edgeType, int limit);
+
+    static native Object[] edgesScan(long txn, String edgeType, int limit);
+
+    /* Vector search */
+    /** Returns Object[2]: long[] nodeIds, float[] distances. */
+    static native Object[] vectorSearch(long db, float[] vector, int k, int efSearch);
+
+    static native Object[] vectorSearchTxn(long txn, float[] vector, int k, int efSearch);
+
+    /* Full-text search */
+    static native void ftsIndex(long txn, long nodeId, String text);
+
+    /** Returns Object[2]: long[] nodeIds, float[] scores. */
+    static native Object[] ftsSearch(long db, String query, int limit);
+
+    static native Object[] ftsSearchFuzzy(long db, String query, int limit,
+                                          int maxDistance, int minTermLength);
+
+    static native Object[] ftsSearchTxn(long txn, String query, int limit);
+
+    static native Object[] ftsSearchFuzzyTxn(long txn, String query, int limit,
+                                             int maxDistance, int minTermLength);
+
+    /* Streams */
+    static native void streamPublish(long txn, String stream, String kind, Object payload);
+
+    static native long streamPublishGetSequence(long txn, String stream, String kind,
+                                                Object payload);
+
+    /** Returns Object[3]: long[] sequences, String[] kinds, Object[] payloads. */
+    static native Object[] streamRead(long db, String stream, long afterSequence,
+                                      int limit, int timeoutMs);
+
+    /** Returns Object[2]: Long offset (nullable), Boolean exists. */
+    static native Object[] streamGetOffset(long db, String stream, String consumer);
+
+    static native long streamGetLastSequence(long db, String stream);
+
+    static native void streamSetOffset(long txn, String stream, String consumer, long sequence);
+
+    static native void streamTrim(long txn, String stream, long throughSequence);
+
+    /* Query engine */
+    static native long queryPrepare(long db, String cypher);
+
+    static native void queryBind(long query, String name, Object value);
+
+    static native void queryBindVector(long query, String name, float[] vector);
+
+    static native long queryExecute(long query, long txn);
+
+    static native boolean queryWrites(long db, String cypher);
+
+    static native boolean resultNext(long result);
+
+    static native int resultColumnCount(long result);
+
+    static native String resultColumnName(long result, int index);
+
+    static native Object resultGet(long result, int index);
+
+    static native void resultFree(long result);
+
+    static native void queryFree(long query);
+
+    /* Query cache */
+    static native void cacheClear(long db);
+
+    /** Returns Object[3]: Integer entries, Long hits, Long misses. */
+    static native Object[] cacheStats(long db);
+
+    /* Embedding helpers */
+    static native float[] hashEmbed(String text, int dimensions);
+
+    static native long embeddingClientCreate(String endpoint, String model,
+                                             int apiFormat, String apiKey, int timeoutMs);
+
+    static native float[] embeddingClientEmbed(long client, String text);
+
+    static native void embeddingClientFree(long client);
+}

--- a/bindings/java/src/main/java/io/latticedb/Native.java
+++ b/bindings/java/src/main/java/io/latticedb/Native.java
@@ -19,7 +19,14 @@ final class Native {
     static native long open(String path, boolean create, boolean readOnly,
                             int cacheSizeMB, int pageSize, boolean enableVector,
                             int vectorDimensions, boolean enableWal,
-                            boolean enableAdjacencyCache);
+                            boolean enableAdjacencyCache, boolean lock);
+
+    static native byte[] serialize(long db);
+
+    static native long deserialize(byte[] bytes, int cacheSizeMB, int pageSize,
+                                   boolean enableVector, int vectorDimensions,
+                                   boolean enableWal, boolean enableAdjacencyCache,
+                                   boolean lock);
 
     static native void close(long db);
 

--- a/bindings/java/src/main/java/io/latticedb/NativeLoader.java
+++ b/bindings/java/src/main/java/io/latticedb/NativeLoader.java
@@ -1,0 +1,41 @@
+package io.latticedb;
+
+/**
+ * Loads the native LatticeDB JNI library.
+ *
+ * Resolution order:
+ * <ol>
+ *   <li>{@code latticedb.native.dir} system property (directory containing
+ *       {@code liblattice_jni} and {@code liblattice})</li>
+ *   <li>{@code LATTICE_NATIVE_DIR} environment variable</li>
+ *   <li>{@code java.library.path} via {@link System#loadLibrary(String)}</li>
+ * </ol>
+ */
+final class NativeLoader {
+    private static volatile boolean loaded = false;
+
+    private NativeLoader() {
+    }
+
+    static synchronized void load() {
+        if (loaded) {
+            return;
+        }
+        String dir = System.getProperty("latticedb.native.dir");
+        if (dir == null || dir.isEmpty()) {
+            dir = System.getenv("LATTICE_NATIVE_DIR");
+        }
+        String os = System.getProperty("os.name", "").toLowerCase();
+        String ext = os.contains("win") ? "dll" : os.contains("mac") || os.contains("darwin") ? "dylib" : "so";
+        String prefix = os.contains("win") ? "" : "lib";
+        if (dir != null && !dir.isEmpty()) {
+            java.nio.file.Path abs = java.nio.file.Path.of(dir).toAbsolutePath().normalize();
+            String sep = abs.getFileSystem().getSeparator();
+            System.load(abs + sep + prefix + "lattice_jni." + ext);
+            loaded = true;
+            return;
+        }
+        System.loadLibrary("lattice_jni");
+        loaded = true;
+    }
+}

--- a/bindings/java/src/main/java/io/latticedb/Node.java
+++ b/bindings/java/src/main/java/io/latticedb/Node.java
@@ -1,0 +1,19 @@
+package io.latticedb;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A graph node returned by transaction operations.
+ *
+ * @param id         stable node id
+ * @param labels     labels attached to the node
+ * @param properties property map
+ */
+public record Node(long id, List<String> labels, Map<String, Object> properties) {
+    public Node {
+        labels = labels == null ? List.of() : Collections.unmodifiableList(labels);
+        properties = properties == null ? Map.of() : Collections.unmodifiableMap(properties);
+    }
+}

--- a/bindings/java/src/main/java/io/latticedb/OpenOptions.java
+++ b/bindings/java/src/main/java/io/latticedb/OpenOptions.java
@@ -4,7 +4,7 @@ import java.util.Objects;
 
 /**
  * Options for opening a database, mirroring the Go binding's OpenOptions and
- * the native {@code lattice_open_options_v3} struct. All values have sane
+ * the native {@code lattice_open_options_v4} struct. All values have sane
  * defaults; use the builder to override them.
  */
 public final class OpenOptions {
@@ -16,6 +16,7 @@ public final class OpenOptions {
     private int vectorDimensions = 128;
     private boolean enableWal = true;
     private boolean enableAdjacencyCache = false;
+    private boolean lock = true;
 
     private OpenOptions() {
     }
@@ -71,6 +72,17 @@ public final class OpenOptions {
         return this;
     }
 
+    /**
+     * Take a lock on the database file. Default true.
+     *
+     * <p>Turn this off only for filesystems where locking does not work; it
+     * does not make concurrent access safe.</p>
+     */
+    public OpenOptions lock(boolean lock) {
+        this.lock = lock;
+        return this;
+    }
+
     boolean create() { return create; }
     boolean readOnly() { return readOnly; }
     int cacheSizeMB() { return cacheSizeMB; }
@@ -79,6 +91,7 @@ public final class OpenOptions {
     int vectorDimensions() { return vectorDimensions; }
     boolean enableWal() { return enableWal; }
     boolean enableAdjacencyCache() { return enableAdjacencyCache; }
+    boolean lock() { return lock; }
 
     @Override
     public boolean equals(Object o) {
@@ -88,12 +101,13 @@ public final class OpenOptions {
                 && enableVectors == other.enableVectors
                 && vectorDimensions == other.vectorDimensions
                 && enableWal == other.enableWal
-                && enableAdjacencyCache == other.enableAdjacencyCache;
+                && enableAdjacencyCache == other.enableAdjacencyCache
+                && lock == other.lock;
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(create, readOnly, cacheSizeMB, pageSize, enableVectors,
-                vectorDimensions, enableWal, enableAdjacencyCache);
+                vectorDimensions, enableWal, enableAdjacencyCache, lock);
     }
 }

--- a/bindings/java/src/main/java/io/latticedb/OpenOptions.java
+++ b/bindings/java/src/main/java/io/latticedb/OpenOptions.java
@@ -1,0 +1,99 @@
+package io.latticedb;
+
+import java.util.Objects;
+
+/**
+ * Options for opening a database, mirroring the Go binding's OpenOptions and
+ * the native {@code lattice_open_options_v3} struct. All values have sane
+ * defaults; use the builder to override them.
+ */
+public final class OpenOptions {
+    private boolean create = false;
+    private boolean readOnly = false;
+    private int cacheSizeMB = 100;
+    private int pageSize = 4096;
+    private boolean enableVectors = false;
+    private int vectorDimensions = 128;
+    private boolean enableWal = true;
+    private boolean enableAdjacencyCache = false;
+
+    private OpenOptions() {
+    }
+
+    public static OpenOptions defaults() {
+        return new OpenOptions();
+    }
+
+    public OpenOptions create(boolean create) {
+        this.create = create;
+        return this;
+    }
+
+    public OpenOptions readOnly(boolean readOnly) {
+        this.readOnly = readOnly;
+        return this;
+    }
+
+    public OpenOptions cacheSizeMB(int cacheSizeMB) {
+        this.cacheSizeMB = cacheSizeMB;
+        return this;
+    }
+
+    public OpenOptions pageSize(int pageSize) {
+        this.pageSize = pageSize;
+        return this;
+    }
+
+    /** Enable vector storage for embeddings. */
+    public OpenOptions enableVectors(boolean enableVectors) {
+        this.enableVectors = enableVectors;
+        return this;
+    }
+
+    /** Vector dimensions, 1..4096. Default 128. */
+    public OpenOptions vectorDimensions(int vectorDimensions) {
+        if (vectorDimensions < 1 || vectorDimensions > 4096) {
+            throw new IllegalArgumentException("vectorDimensions must be in 1..4096");
+        }
+        this.vectorDimensions = vectorDimensions;
+        return this;
+    }
+
+    /** Enable WAL-backed transactions. Default true. */
+    public OpenOptions enableWal(boolean enableWal) {
+        this.enableWal = enableWal;
+        return this;
+    }
+
+    /** Enable the in-memory graph adjacency cache. Default false. */
+    public OpenOptions enableAdjacencyCache(boolean enableAdjacencyCache) {
+        this.enableAdjacencyCache = enableAdjacencyCache;
+        return this;
+    }
+
+    boolean create() { return create; }
+    boolean readOnly() { return readOnly; }
+    int cacheSizeMB() { return cacheSizeMB; }
+    int pageSize() { return pageSize; }
+    boolean enableVectors() { return enableVectors; }
+    int vectorDimensions() { return vectorDimensions; }
+    boolean enableWal() { return enableWal; }
+    boolean enableAdjacencyCache() { return enableAdjacencyCache; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof OpenOptions other)) return false;
+        return create == other.create && readOnly == other.readOnly
+                && cacheSizeMB == other.cacheSizeMB && pageSize == other.pageSize
+                && enableVectors == other.enableVectors
+                && vectorDimensions == other.vectorDimensions
+                && enableWal == other.enableWal
+                && enableAdjacencyCache == other.enableAdjacencyCache;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(create, readOnly, cacheSizeMB, pageSize, enableVectors,
+                vectorDimensions, enableWal, enableAdjacencyCache);
+    }
+}

--- a/bindings/java/src/main/java/io/latticedb/QueryCacheStats.java
+++ b/bindings/java/src/main/java/io/latticedb/QueryCacheStats.java
@@ -1,0 +1,5 @@
+package io.latticedb;
+
+/** Query cache statistics. */
+public record QueryCacheStats(int entries, long hits, long misses) {
+}

--- a/bindings/java/src/main/java/io/latticedb/QueryErrorStage.java
+++ b/bindings/java/src/main/java/io/latticedb/QueryErrorStage.java
@@ -1,0 +1,29 @@
+package io.latticedb;
+
+/** Query diagnostic stage, mirroring {@code lattice_query_error_stage}. */
+public enum QueryErrorStage {
+    NONE(0),
+    PARSE(1),
+    SEMANTIC(2),
+    PLAN(3),
+    EXECUTION(4);
+
+    private final int stage;
+
+    QueryErrorStage(int stage) {
+        this.stage = stage;
+    }
+
+    public int stage() {
+        return stage;
+    }
+
+    static QueryErrorStage fromStage(int stage) {
+        for (QueryErrorStage s : values()) {
+            if (s.stage == stage) {
+                return s;
+            }
+        }
+        throw new IllegalArgumentException("unknown query error stage: " + stage);
+    }
+}

--- a/bindings/java/src/main/java/io/latticedb/QueryException.java
+++ b/bindings/java/src/main/java/io/latticedb/QueryException.java
@@ -1,0 +1,70 @@
+package io.latticedb;
+
+import java.util.Optional;
+
+/**
+ * Exception thrown when a Cypher query fails to prepare or execute.
+ *
+ * Carries structured diagnostics: the pipeline stage that failed, an optional
+ * engine diagnostic code, and an optional source location.
+ */
+public class QueryException extends RuntimeException {
+    private final ErrorCode code;
+    private final QueryErrorStage stage;
+    private final String diagnosticCode;
+    private final boolean hasLocation;
+    private final int line;
+    private final int column;
+    private final int length;
+
+    QueryException(int code, int stage, String message, String diagnosticCode,
+                   boolean hasLocation, int line, int column, int length) {
+        super(message);
+        this.code = ErrorCode.fromCode(code);
+        this.stage = QueryErrorStage.fromStage(stage);
+        this.diagnosticCode = diagnosticCode;
+        this.hasLocation = hasLocation;
+        this.line = line;
+        this.column = column;
+        this.length = length;
+    }
+
+    public ErrorCode getCode() {
+        return code;
+    }
+
+    /** The pipeline stage that failed (parse, semantic, plan, execution). */
+    public QueryErrorStage getStage() {
+        return stage;
+    }
+
+    /** Engine diagnostic code, if any (e.g. {@code unknown_label}). */
+    public Optional<String> getDiagnosticCode() {
+        return Optional.ofNullable(diagnosticCode);
+    }
+
+    public boolean hasLocation() {
+        return hasLocation;
+    }
+
+    /** 1-based line of the failing token, or 0 when unavailable. */
+    public int getLine() {
+        return line;
+    }
+
+    /** 1-based column of the failing token, or 0 when unavailable. */
+    public int getColumn() {
+        return column;
+    }
+
+    /** Length of the failing token span, or 0 when unavailable. */
+    public int getLength() {
+        return length;
+    }
+
+    @Override
+    public String getMessage() {
+        String base = super.getMessage();
+        return diagnosticCode != null ? base + " (" + diagnosticCode + ")" : base;
+    }
+}

--- a/bindings/java/src/main/java/io/latticedb/QueryResult.java
+++ b/bindings/java/src/main/java/io/latticedb/QueryResult.java
@@ -1,0 +1,15 @@
+package io.latticedb;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Result of a Cypher query: column names plus one map per row keyed by
+ * column name.
+ */
+public record QueryResult(List<String> columns, List<Map<String, Object>> rows) {
+    public QueryResult {
+        columns = columns == null ? List.of() : List.copyOf(columns);
+        rows = rows == null ? List.of() : List.copyOf(rows);
+    }
+}

--- a/bindings/java/src/main/java/io/latticedb/StreamRecord.java
+++ b/bindings/java/src/main/java/io/latticedb/StreamRecord.java
@@ -1,0 +1,5 @@
+package io.latticedb;
+
+/** One record read from a durable stream. */
+public record StreamRecord(long sequence, String kind, Object payload) {
+}

--- a/bindings/java/src/main/java/io/latticedb/Transaction.java
+++ b/bindings/java/src/main/java/io/latticedb/Transaction.java
@@ -1,0 +1,386 @@
+package io.latticedb;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * An active transaction. Obtained via {@link Database#beginRead()},
+ * {@link Database#beginWrite()}, or the auto-managed {@code read}/
+ * {@code write}/{@code query} helpers.
+ *
+ * <p>Commit or rollback ends the transaction; closing an uncommitted
+ * transaction rolls it back.
+ */
+public final class Transaction implements AutoCloseable {
+    private final Database db;
+    private final boolean readOnly;
+    private long handle;
+    private boolean active = true;
+
+    Transaction(Database db, boolean readOnly) {
+        this.db = db;
+        this.readOnly = readOnly;
+        this.handle = Native.begin(db.handle(), readOnly);
+    }
+
+    public Database getDatabase() {
+        return db;
+    }
+
+    public synchronized boolean isReadOnly() {
+        return readOnly && active;
+    }
+
+    public synchronized boolean isActive() {
+        return active;
+    }
+
+    /** Commits the transaction. A committed handle must not be reused. */
+    public synchronized void commit() {
+        ensureActive();
+        Native.commit(handle);
+        handle = 0;
+        active = false;
+    }
+
+    /**
+     * Rolls back the transaction. Rolling back an already-ended transaction
+     * is a no-op (mirrors the Go binding), so try-with-resources cleanup is
+     * always safe.
+     */
+    public synchronized void rollback() {
+        if (!active) {
+            return;
+        }
+        Native.rollback(handle);
+        handle = 0;
+        active = false;
+    }
+
+    @Override
+    public synchronized void close() {
+        rollback();
+    }
+
+    long handle() {
+        if (!active) {
+            throw new LatticeException(ErrorCode.TXN_ABORTED, "transaction is not active");
+        }
+        return handle;
+    }
+
+    private void ensureActive() {
+        if (!active) {
+            throw new LatticeException(ErrorCode.TXN_ABORTED, "transaction is not active");
+        }
+    }
+
+    private void ensureWritable() {
+        ensureActive();
+        if (readOnly) {
+            throw new LatticeException(ErrorCode.READ_ONLY,
+                    "cannot write in a read-only transaction");
+        }
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Nodes                                                               */
+    /* ------------------------------------------------------------------ */
+
+    /** Creates a node with labels and properties. */
+    public Node createNode(List<String> labels, Map<String, Object> properties) {
+        ensureWritable();
+        String first = labels == null || labels.isEmpty() ? "" : labels.get(0);
+        long id = Native.nodeCreate(handle, first);
+        if (labels != null) {
+            for (int i = 1; i < labels.size(); i++) {
+                Native.nodeAddLabel(handle, id, labels.get(i));
+            }
+        }
+        Map<String, Object> props = new LinkedHashMap<>();
+        if (properties != null) {
+            for (Map.Entry<String, Object> e : properties.entrySet()) {
+                Native.nodeSetProperty(handle, id, e.getKey(), e.getValue());
+                props.put(e.getKey(), e.getValue());
+            }
+        }
+        return new Node(id, labels == null ? List.of() : List.copyOf(labels), props);
+    }
+
+    public Node createNode(List<String> labels) {
+        return createNode(labels, null);
+    }
+
+    public Node createNode() {
+        return createNode(null, null);
+    }
+
+    public void deleteNode(long nodeId) {
+        ensureWritable();
+        Native.nodeDelete(handle, nodeId);
+    }
+
+    public boolean nodeExists(long nodeId) {
+        ensureActive();
+        return Native.nodeExists(handle, nodeId);
+    }
+
+    /**
+     * Loads a node's labels by id; empty when the node does not exist.
+     * Properties are not populated (the C API exposes per-property reads).
+     */
+    public Optional<Node> getNode(long nodeId) {
+        ensureActive();
+        if (!Native.nodeExists(handle, nodeId)) {
+            return Optional.empty();
+        }
+        return Optional.of(new Node(nodeId,
+                List.of(Native.nodeGetLabels(handle, nodeId)), Map.of()));
+    }
+
+    public void addLabel(long nodeId, String label) {
+        ensureWritable();
+        Native.nodeAddLabel(handle, nodeId, label);
+    }
+
+    public void removeLabel(long nodeId, String label) {
+        ensureWritable();
+        Native.nodeRemoveLabel(handle, nodeId, label);
+    }
+
+    public void setProperty(long nodeId, String key, Object value) {
+        ensureWritable();
+        Native.nodeSetProperty(handle, nodeId, key, value);
+    }
+
+    /** Property value, or empty when the key is absent. */
+    public Optional<Object> getProperty(long nodeId, String key) {
+        ensureActive();
+        return Optional.ofNullable(Native.nodeGetProperty(handle, nodeId, key));
+    }
+
+    public void setVector(long nodeId, String key, float[] vector) {
+        ensureWritable();
+        Native.nodeSetVector(handle, nodeId, key, vector);
+    }
+
+    /** Indexes text on a node for BM25 full-text search. */
+    public void ftsIndex(long nodeId, String text) {
+        ensureWritable();
+        Native.ftsIndex(handle, nodeId, text);
+    }
+
+    /**
+     * Finds node ids through a required explicit equality index. Throws
+     * {@link ErrorCode#UNSUPPORTED} when the index does not exist.
+     */
+    public List<Long> findNodesByLabelProperty(String label, String property,
+                                               Object value, int limit) {
+        ensureActive();
+        return Database.toIdList(
+                Native.findNodesByLabelProperty(handle, label, property, value, limit));
+    }
+
+    /** Inserts multiple vector-bearing nodes with the same label in one call. */
+    public List<Long> batchInsertVectors(String label, float[][] vectors) {
+        ensureWritable();
+        return Database.toIdList(Native.batchInsert(handle, label, vectors));
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Edges                                                               */
+    /* ------------------------------------------------------------------ */
+
+    public Edge createEdge(long sourceId, long targetId, String type,
+                           Map<String, Object> properties) {
+        ensureWritable();
+        long edgeId = Native.edgeCreate(handle, sourceId, targetId, type);
+        Map<String, Object> props = new LinkedHashMap<>();
+        if (properties != null) {
+            for (Map.Entry<String, Object> e : properties.entrySet()) {
+                Native.edgeSetProperty(handle, edgeId, e.getKey(), e.getValue());
+                props.put(e.getKey(), e.getValue());
+            }
+        }
+        return new Edge(edgeId, sourceId, targetId, type, props);
+    }
+
+    public Edge createEdge(long sourceId, long targetId, String type) {
+        return createEdge(sourceId, targetId, type, null);
+    }
+
+    public void deleteEdge(long sourceId, long targetId, String type) {
+        ensureWritable();
+        Native.edgeDelete(handle, sourceId, targetId, type);
+    }
+
+    public void setEdgeProperty(long edgeId, String key, Object value) {
+        ensureWritable();
+        Native.edgeSetProperty(handle, edgeId, key, value);
+    }
+
+    public Optional<Object> getEdgeProperty(long edgeId, String key) {
+        ensureActive();
+        return Optional.ofNullable(Native.edgeGetProperty(handle, edgeId, key));
+    }
+
+    public void removeEdgeProperty(long edgeId, String key) {
+        ensureWritable();
+        Native.edgeRemoveProperty(handle, edgeId, key);
+    }
+
+    /**
+     * Finds edge ids through a required explicit equality index. Throws
+     * {@link ErrorCode#UNSUPPORTED} when the index does not exist.
+     */
+    public List<Long> findEdgesByTypeProperty(String edgeType, String property,
+                                              Object value, int limit) {
+        ensureActive();
+        return Database.toIdList(
+                Native.findEdgesByTypeProperty(handle, edgeType, property, value, limit));
+    }
+
+    public List<Edge> getOutgoingEdges(long nodeId) {
+        ensureActive();
+        return toEdges(Native.edgesOutgoing(handle, nodeId));
+    }
+
+    public List<Edge> getIncomingEdges(long nodeId) {
+        ensureActive();
+        return toEdges(Native.edgesIncoming(handle, nodeId));
+    }
+
+    public List<Edge> getOutgoingEdgesByType(long nodeId, String edgeType, int limit) {
+        ensureActive();
+        return toEdges(Native.edgesOutgoingByType(handle, nodeId, edgeType, limit));
+    }
+
+    public List<Edge> getIncomingEdgesByType(long nodeId, String edgeType, int limit) {
+        ensureActive();
+        return toEdges(Native.edgesIncomingByType(handle, nodeId, edgeType, limit));
+    }
+
+    /** Scans edges of a type ({@code null} = all). Admin/rebuild use. */
+    public List<Edge> scanEdges(String edgeType, int limit) {
+        ensureActive();
+        return toEdges(Native.edgesScan(handle, edgeType, limit));
+    }
+
+    static List<Edge> toEdges(Object[] packed) {
+        long[] triples = (long[]) packed[0];
+        String[] types = (String[]) packed[1];
+        List<Edge> edges = new ArrayList<>(types.length);
+        for (int i = 0; i < types.length; i++) {
+            edges.add(new Edge(triples[3 * i], triples[3 * i + 1],
+                    triples[3 * i + 2], types[i], Map.of()));
+        }
+        return edges;
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Search (transaction-scoped)                                         */
+    /* ------------------------------------------------------------------ */
+
+    /** Vector search within this transaction's snapshot. */
+    public List<VectorSearchResult> queryVector(float[] vector, int k, int efSearch) {
+        ensureActive();
+        return Database.zipVectorResults(
+                Native.vectorSearchTxn(handle, vector, k, efSearch));
+    }
+
+    /** Full-text search within this transaction's snapshot. */
+    public List<FTSSearchResult> ftsSearch(String query, FTSSearchOptions opts) {
+        ensureActive();
+        return Database.zipFtsResults(Native.ftsSearchTxn(handle, query,
+                opts == null ? 10 : opts.limit()));
+    }
+
+    /** Fuzzy full-text search within this transaction's snapshot. */
+    public List<FTSSearchResult> ftsSearchFuzzy(String query, FTSSearchOptions opts) {
+        ensureActive();
+        Object[] out = Native.ftsSearchFuzzyTxn(handle, query,
+                opts == null ? 10 : opts.limit(),
+                opts == null ? 0 : opts.maxDistance(),
+                opts == null ? 0 : opts.minTermLength());
+        return Database.zipFtsResults(out);
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Streams (write side)                                                */
+    /* ------------------------------------------------------------------ */
+
+    /** Publishes a record; kind {@code null} defaults to "message". */
+    public void publishStream(String stream, String kind, Object payload) {
+        ensureWritable();
+        Native.streamPublish(handle, stream, kind, payload);
+    }
+
+    /** Publishes and returns the sequence assigned within this transaction. */
+    public long publishStreamGetSequence(String stream, String kind, Object payload) {
+        ensureWritable();
+        return Native.streamPublishGetSequence(handle, stream, kind, payload);
+    }
+
+    public void setStreamOffset(String stream, String consumer, long sequence) {
+        ensureWritable();
+        Native.streamSetOffset(handle, stream, consumer, sequence);
+    }
+
+    public void trimStream(String stream, long throughSequence) {
+        ensureWritable();
+        Native.streamTrim(handle, stream, throughSequence);
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Query                                                               */
+    /* ------------------------------------------------------------------ */
+
+    /** Prepares, binds and executes a Cypher query inside this transaction. */
+    public QueryResult query(String cypher, Map<String, Object> parameters) {
+        ensureActive();
+        long q = Native.queryPrepare(db.handle(), cypher);
+        try {
+            if (parameters != null) {
+                for (Map.Entry<String, Object> e : parameters.entrySet()) {
+                    if (e.getValue() instanceof float[] vector) {
+                        Native.queryBindVector(q, e.getKey(), vector);
+                    } else {
+                        Native.queryBind(q, e.getKey(), e.getValue());
+                    }
+                }
+            }
+            long result = Native.queryExecute(q, handle);
+            try {
+                return collectResult(result);
+            } finally {
+                Native.resultFree(result);
+            }
+        } finally {
+            Native.queryFree(q);
+        }
+    }
+
+    public QueryResult query(String cypher) {
+        return query(cypher, null);
+    }
+
+    private static QueryResult collectResult(long result) {
+        int columnCount = Native.resultColumnCount(result);
+        String[] columns = new String[columnCount];
+        for (int i = 0; i < columnCount; i++) {
+            columns[i] = Native.resultColumnName(result, i);
+        }
+        List<Map<String, Object>> rows = new ArrayList<>();
+        while (Native.resultNext(result)) {
+            Map<String, Object> row = new LinkedHashMap<>();
+            for (int i = 0; i < columnCount; i++) {
+                row.put(columns[i], Native.resultGet(result, i));
+            }
+            rows.add(row);
+        }
+        return new QueryResult(List.of(columns), rows);
+    }
+}

--- a/bindings/java/src/main/java/io/latticedb/VectorSearchOptions.java
+++ b/bindings/java/src/main/java/io/latticedb/VectorSearchOptions.java
@@ -1,0 +1,29 @@
+package io.latticedb;
+
+/** Options for {@code Database#vectorSearch}. */
+public final class VectorSearchOptions {
+    private int k = 10;
+    private int efSearch = 0; /* 0 = engine default */
+
+    private VectorSearchOptions() {
+    }
+
+    public static VectorSearchOptions defaults() {
+        return new VectorSearchOptions();
+    }
+
+    /** Number of results to return. Default 10. */
+    public VectorSearchOptions k(int k) {
+        this.k = k;
+        return this;
+    }
+
+    /** HNSW ef parameter; 0 uses the engine default. */
+    public VectorSearchOptions efSearch(int efSearch) {
+        this.efSearch = efSearch;
+        return this;
+    }
+
+    int k() { return k; }
+    int efSearch() { return efSearch; }
+}

--- a/bindings/java/src/main/java/io/latticedb/VectorSearchResult.java
+++ b/bindings/java/src/main/java/io/latticedb/VectorSearchResult.java
@@ -1,0 +1,5 @@
+package io.latticedb;
+
+/** One vector-search hit. */
+public record VectorSearchResult(long nodeId, float distance) {
+}

--- a/bindings/java/src/main/java/io/latticedb/examples/KnowledgeGraphExample.java
+++ b/bindings/java/src/main/java/io/latticedb/examples/KnowledgeGraphExample.java
@@ -1,0 +1,91 @@
+package io.latticedb.examples;
+
+import io.latticedb.Database;
+import io.latticedb.Embedding;
+import io.latticedb.FTSSearchOptions;
+import io.latticedb.Node;
+import io.latticedb.OpenOptions;
+import io.latticedb.QueryResult;
+import io.latticedb.Transaction;
+
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Complete example: build a small knowledge graph, store embeddings, index
+ * text, then query across graph, vector, and full-text search modes.
+ *
+ * Run from bindings/java:
+ * <pre>
+ * mvn -q compile exec:java@run-example -Dexec.args=/tmp/knowledge.db
+ * </pre>
+ */
+public final class KnowledgeGraphExample {
+    public static void main(String[] args) throws Exception {
+        String path = args.length > 0 ? args[0]
+                : Files.createTempFile("knowledge", ".db").toString();
+        Files.deleteIfExists(java.nio.file.Path.of(path));
+
+        int dims = 8;
+        try (Database db = Database.open(path,
+                OpenOptions.defaults().create(true).enableVectors(true).vectorDimensions(dims))) {
+
+            // --- Build the graph ---
+            try (Transaction txn = db.beginWrite()) {
+                Node alice = txn.createNode(List.of("Person"),
+                        Map.of("name", "Alice", "field", "ML"));
+                Node bob = txn.createNode(List.of("Person"),
+                        Map.of("name", "Bob", "field", "Systems"));
+
+                List<String[]> docs = List.of(
+                        new String[]{"Attention Is All You Need",
+                                "The transformer architecture uses self-attention layers"},
+                        new String[]{"Scaling Laws for LLMs",
+                                "Model performance scales predictably with compute"},
+                        new String[]{"LSM Trees",
+                                "Log-structured merge trees optimize write-heavy workloads"});
+
+                for (String[] doc : docs) {
+                    Node document = txn.createNode(List.of("Document"),
+                            Map.of("title", doc[0]));
+                    Node chunk = txn.createNode(List.of("Chunk"), Map.of("text", doc[1]));
+
+                    txn.setVector(chunk.id(), "embedding",
+                            Embedding.hashEmbed(doc[1], dims));
+                    txn.ftsIndex(chunk.id(), doc[1]);
+
+                    txn.createEdge(chunk.id(), document.id(), "PART_OF");
+                    txn.createEdge(document.id(),
+                            doc[0].startsWith("LSM") ? bob.id() : alice.id(), "AUTHORED_BY");
+                }
+                txn.commit();
+            }
+
+            // --- Query across search modes ---
+            QueryResult results = db.query("""
+                    MATCH (chunk:Chunk)-[:PART_OF]->(doc:Document)-[:AUTHORED_BY]->(author:Person)
+                    RETURN doc.title AS title, chunk.text AS text, author.name AS author
+                    """);
+            for (Map<String, Object> row : results.rows()) {
+                System.out.printf("%s by %s%n", row.get("title"), row.get("author"));
+            }
+
+            // --- Vector similarity ---
+            System.out.println("\nSimilar to 'self-attention':");
+            db.vectorSearch(Embedding.hashEmbed("self-attention transformer", dims),
+                    io.latticedb.VectorSearchOptions.defaults().k(2))
+                .forEach(r -> System.out.printf("  node %d (distance %.4f)%n",
+                        r.nodeId(), r.distance()));
+
+            // --- Full-text search ---
+            System.out.println("\nFTS 'transformer attention':");
+            db.ftsSearch("transformer attention", FTSSearchOptions.defaults())
+                .forEach(r -> System.out.printf("  node %d (score %.4f)%n",
+                        r.nodeId(), r.score()));
+        }
+    }
+
+    private KnowledgeGraphExample() {
+    }
+}

--- a/bindings/java/src/test/java/io/latticedb/DatabaseLifecycleTest.java
+++ b/bindings/java/src/test/java/io/latticedb/DatabaseLifecycleTest.java
@@ -102,20 +102,72 @@ class DatabaseLifecycleTest {
     }
 
     @Test
-    void fileLockedErrorCodeIsMapped() {
-        LatticeException ex = new LatticeException(ErrorCode.FILE_LOCKED, "locked");
-        assertEquals(ErrorCode.FILE_LOCKED, ex.getErrorCode());
+    void databaseLockedErrorCodeIsMapped() {
+        LatticeException ex = new LatticeException(ErrorCode.DATABASE_LOCKED, "locked");
+        assertEquals(ErrorCode.DATABASE_LOCKED, ex.getErrorCode());
         assertEquals(-16, ex.getNativeCode());
-        assertEquals(ErrorCode.FILE_LOCKED, ErrorCode.fromCode(-16));
+        assertEquals(ErrorCode.DATABASE_LOCKED, ErrorCode.fromCode(-16));
     }
 
     @Test
     void optionsDefaultsMatchGoBinding() {
         OpenOptions opts = OpenOptions.defaults();
         assertEquals(OpenOptions.defaults(), opts);
+        assertTrue(opts.lock());
+        assertNotEquals(opts, OpenOptions.defaults().lock(false));
         assertThrows(IllegalArgumentException.class,
                 () -> opts.vectorDimensions(0));
         assertThrows(IllegalArgumentException.class,
                 () -> opts.vectorDimensions(5000));
+    }
+
+    @Test
+    void serializeDeserializeRoundTripIsIndependent() {
+        byte[] snapshot;
+        try (Database db = Database.open(dbPath(), OpenOptions.defaults().create(true))) {
+            db.write(txn -> {
+                txn.createNode(java.util.List.of("Thing"),
+                        java.util.Map.of("name", "before"));
+                return null;
+            });
+            snapshot = db.serialize();
+            assertTrue(snapshot.length > 0);
+
+            db.write(txn -> {
+                txn.createNode(java.util.List.of("Thing"),
+                        java.util.Map.of("name", "after"));
+                return null;
+            });
+        }
+
+        byte[] originalSnapshot = snapshot.clone();
+        try (Database restored = Database.deserialize(snapshot)) {
+            assertEquals("<deserialized>", restored.getPath());
+            long count = restored.read(txn -> (long) txn.query(
+                    "MATCH (n:Thing) RETURN count(n) AS c").rows().get(0).get("c"));
+            assertEquals(1L, count);
+
+            restored.write(txn -> {
+                txn.createNode(java.util.List.of("Thing"));
+                return null;
+            });
+            assertArrayEquals(originalSnapshot, snapshot);
+        }
+    }
+
+    @Test
+    void serializeRejectsAnOpenTransaction() {
+        try (Database db = Database.open(dbPath(), OpenOptions.defaults().create(true));
+             Transaction ignored = db.beginRead()) {
+            LatticeException ex = assertThrows(LatticeException.class, db::serialize);
+            assertEquals(ErrorCode.LOCK_TIMEOUT, ex.getErrorCode());
+        }
+    }
+
+    @Test
+    void deserializeRejectsInvalidBytes() {
+        LatticeException ex = assertThrows(LatticeException.class,
+                () -> Database.deserialize(new byte[] {1, 2, 3}));
+        assertEquals(ErrorCode.CORRUPTION, ex.getErrorCode());
     }
 }

--- a/bindings/java/src/test/java/io/latticedb/DatabaseLifecycleTest.java
+++ b/bindings/java/src/test/java/io/latticedb/DatabaseLifecycleTest.java
@@ -94,6 +94,22 @@ class DatabaseLifecycleTest {
     }
 
     @Test
+    void unknownErrorCodesFallBackToCatchAll() {
+        LatticeException ex = new LatticeException(-999, "something unexpected");
+        assertEquals(ErrorCode.UNKNOWN, ex.getErrorCode());
+        assertEquals(-999, ex.getNativeCode());
+        assertTrue(ex.getMessage().contains("-999"));
+    }
+
+    @Test
+    void fileLockedErrorCodeIsMapped() {
+        LatticeException ex = new LatticeException(ErrorCode.FILE_LOCKED, "locked");
+        assertEquals(ErrorCode.FILE_LOCKED, ex.getErrorCode());
+        assertEquals(-16, ex.getNativeCode());
+        assertEquals(ErrorCode.FILE_LOCKED, ErrorCode.fromCode(-16));
+    }
+
+    @Test
     void optionsDefaultsMatchGoBinding() {
         OpenOptions opts = OpenOptions.defaults();
         assertEquals(OpenOptions.defaults(), opts);

--- a/bindings/java/src/test/java/io/latticedb/DatabaseLifecycleTest.java
+++ b/bindings/java/src/test/java/io/latticedb/DatabaseLifecycleTest.java
@@ -1,0 +1,105 @@
+package io.latticedb;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DatabaseLifecycleTest {
+    @TempDir
+    Path dir;
+
+    private String dbPath() {
+        return dir.resolve("test.db").toString();
+    }
+
+    @Test
+    void versionIsExposed() {
+        String version = Database.version();
+        assertNotNull(version);
+        assertFalse(version.isEmpty());
+    }
+
+    @Test
+    void openCreateAndReopen() {
+        try (Database db = Database.open(dbPath(), OpenOptions.defaults().create(true))) {
+            assertTrue(db.isOpen());
+            assertEquals(dbPath(), db.getPath());
+            db.write(txn -> {
+            txn.createNode(java.util.List.of("Thing"),
+                    java.util.Map.of("name", "n1"));
+            return null;
+        });
+        }
+        try (Database db = Database.open(dbPath())) {
+            long count = db.read(txn -> (long) txn.query(
+                    "MATCH (n:Thing) RETURN count(n) AS c").rows().get(0).get("c"));
+            assertEquals(1L, count);
+        }
+    }
+
+    @Test
+    void openMissingFileFailsWithoutCreate() {
+        assertThrows(LatticeException.class, () -> Database.open(dbPath()));
+    }
+
+    @Test
+    void closeIsIdempotentAndDetectsUseAfterClose() {
+        Database db = Database.open(dbPath(), OpenOptions.defaults().create(true));
+        assertTrue(db.isOpen());
+        db.close();
+        assertFalse(db.isOpen());
+        db.close(); // no-op
+        assertThrows(LatticeException.class, db::cacheClear);
+    }
+
+    @Test
+    void readOnlyDatabaseRejectsWrites() {
+        try (Database db = Database.open(dbPath(),
+                OpenOptions.defaults().create(true).readOnly(false))) {
+            db.write(txn -> null);
+        }
+        try (Database db = Database.open(dbPath(), OpenOptions.defaults().readOnly(true))) {
+            LatticeException ex = assertThrows(LatticeException.class, db::beginWrite);
+            assertEquals(ErrorCode.READ_ONLY, ex.getErrorCode());
+        }
+    }
+
+    @Test
+    void secondWriterTimesOut() {
+        try (Database db = Database.open(dbPath(), OpenOptions.defaults().create(true));
+             Transaction writer = db.beginWrite()) {
+            LatticeException ex = assertThrows(LatticeException.class, db::beginWrite);
+            assertEquals(ErrorCode.LOCK_TIMEOUT, ex.getErrorCode());
+            // readers are fine alongside a writer
+            try (Transaction reader = db.beginRead()) {
+                assertTrue(reader.isReadOnly());
+            }
+        }
+    }
+
+    @Test
+    void writeLambdaRollsBackOnException() {
+        try (Database db = Database.open(dbPath(), OpenOptions.defaults().create(true))) {
+            assertThrows(IllegalStateException.class, () -> db.write(txn -> {
+                txn.createNode(java.util.List.of("Thing"));
+                throw new IllegalStateException("boom");
+            }));
+            long count = db.read(txn -> (long) txn.query(
+                    "MATCH (n:Thing) RETURN count(n) AS c").rows().get(0).get("c"));
+            assertEquals(0L, count);
+        }
+    }
+
+    @Test
+    void optionsDefaultsMatchGoBinding() {
+        OpenOptions opts = OpenOptions.defaults();
+        assertEquals(OpenOptions.defaults(), opts);
+        assertThrows(IllegalArgumentException.class,
+                () -> opts.vectorDimensions(0));
+        assertThrows(IllegalArgumentException.class,
+                () -> opts.vectorDimensions(5000));
+    }
+}

--- a/bindings/java/src/test/java/io/latticedb/GraphOperationsTest.java
+++ b/bindings/java/src/test/java/io/latticedb/GraphOperationsTest.java
@@ -1,0 +1,237 @@
+package io.latticedb;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GraphOperationsTest {
+    @TempDir
+    Path dir;
+
+    @Test
+    void nodeCrudLabelsAndProperties() {
+        try (Database db = Database.open(dir.resolve("g.db").toString(),
+                OpenOptions.defaults().create(true))) {
+            try (Transaction tx = db.beginWrite()) {
+                Node alice = tx.createNode(List.of("Person"), Map.of("name", "Alice"));
+                tx.createEdge(alice.id(), alice.id(), "SELF");
+
+                // labels
+                tx.addLabel(alice.id(), "Employee");
+                assertEquals(List.of("Person", "Employee"),
+                        tx.getNode(alice.id()).orElseThrow().labels());
+                tx.removeLabel(alice.id(), "Employee");
+
+                // property round-trip of every scalar type plus nesting
+                Map<String, Object> props = Map.of(
+                        "b", true,
+                        "i", 42L,
+                        "d", 3.14d,
+                        "s", "hello",
+                        "bytes", new byte[]{1, 2, 3},
+                        "list", List.of(1L, "two", false),
+                        "map", Map.of("nested", List.of("deep")));
+                props.forEach((k, v) -> tx.setProperty(alice.id(), k, v));
+
+                assertEquals(Boolean.TRUE, tx.getProperty(alice.id(), "b").orElseThrow());
+                assertEquals(42L, ((Number) tx.getProperty(alice.id(), "i").orElseThrow()).longValue());
+                assertEquals(3.14d, ((Number) tx.getProperty(alice.id(), "d").orElseThrow()).doubleValue(), 1e-9);
+                assertEquals("hello", tx.getProperty(alice.id(), "s").orElseThrow());
+                assertArrayEquals(new byte[]{1, 2, 3}, (byte[]) tx.getProperty(alice.id(), "bytes").orElseThrow());
+                Object list = tx.getProperty(alice.id(), "list").orElseThrow();
+                assertEquals(List.of(1L, "two", false), list);
+                Object map = tx.getProperty(alice.id(), "map").orElseThrow();
+                assertEquals(Map.of("nested", List.of("deep")), map);
+                assertTrue(tx.getProperty(alice.id(), "missing").isEmpty());
+
+                tx.commit();
+
+                // delete after commit boundary in a fresh write txn
+                try (Transaction tx2 = db.beginWrite()) {
+                    tx2.deleteNode(alice.id());
+                    tx2.commit();
+                }
+                try (Transaction tx3 = db.beginRead()) {
+                    assertFalse(tx3.nodeExists(alice.id()));
+                    assertTrue(tx3.getNode(alice.id()).isEmpty());
+                }
+            }
+        }
+    }
+
+    @Test
+    void largeCollectionsAndInvalidMapKeysAreHandledSafely() {
+        try (Database db = Database.open(dir.resolve("collections.db").toString(),
+                OpenOptions.defaults().create(true));
+             Transaction tx = db.beginWrite()) {
+            Node node = tx.createNode(List.of("Collection"));
+            List<Integer> input = java.util.stream.IntStream.range(0, 2_000)
+                    .boxed().toList();
+            tx.setProperty(node.id(), "items", input);
+
+            List<?> output = (List<?>) tx.getProperty(node.id(), "items").orElseThrow();
+            assertEquals(2_000, output.size());
+            assertEquals(0L, output.get(0));
+            assertEquals(1_999L, output.get(1_999));
+
+            LatticeException ex = assertThrows(LatticeException.class,
+                    () -> tx.setProperty(node.id(), "invalid", Map.of(1, "value")));
+            assertEquals(ErrorCode.INVALID_ARG, ex.getErrorCode());
+        }
+    }
+
+    @Test
+    void edgesTraversalAndProperties() {
+        try (Database db = Database.open(dir.resolve("e.db").toString(),
+                OpenOptions.defaults().create(true))) {
+            try (Transaction tx = db.beginWrite()) {
+                Node a = tx.createNode(List.of("N"), Map.of("name", "a"));
+                Node b = tx.createNode(List.of("N"), Map.of("name", "b"));
+                Node c = tx.createNode(List.of("N"), Map.of("name", "c"));
+
+                Edge e1 = tx.createEdge(a.id(), b.id(), "LINKS", Map.of("weight", 5));
+                tx.createEdge(b.id(), c.id(), "LINKS");
+                Edge typed = tx.createEdge(a.id(), c.id(), "LIKES");
+                tx.setEdgeProperty(typed.id(), "stars", 4);
+
+                assertEquals(e1.sourceId(), a.id());
+                assertEquals(e1.targetId(), b.id());
+
+                List<Edge> out = tx.getOutgoingEdges(a.id());
+                assertEquals(2, out.size());
+                List<Edge> outLinks = tx.getOutgoingEdgesByType(a.id(), "LINKS", 0);
+                assertEquals(1, outLinks.size());
+                assertEquals("LINKS", outLinks.get(0).type());
+                List<Edge> limited = tx.getOutgoingEdgesByType(a.id(), "LINKS", 0);
+                assertEquals(1, limited.size());
+
+                List<Edge> inc = tx.getIncomingEdges(b.id());
+                assertEquals(1, inc.size());
+                assertEquals(a.id(), inc.get(0).sourceId());
+
+                assertEquals(5L, ((Number) tx.getEdgeProperty(e1.id(), "weight")
+                        .orElseThrow()).longValue());
+                tx.removeEdgeProperty(e1.id(), "weight");
+                assertTrue(tx.getEdgeProperty(e1.id(), "weight").isEmpty());
+
+                tx.deleteEdge(a.id(), b.id(), "LINKS");
+                assertEquals(1, tx.getOutgoingEdges(a.id()).size());
+
+                // scan
+                assertTrue(tx.scanEdges(null, 0).size() >= 2);
+
+                tx.commit();
+            }
+        }
+    }
+
+    @Test
+    void propertyIndexesAndLookups() {
+        try (Database db = Database.open(dir.resolve("idx.db").toString(),
+                OpenOptions.defaults().create(true))) {
+            try (Transaction tx = db.beginWrite()) {
+                for (int i = 0; i < 5; i++) {
+                    tx.createNode(List.of("Item"), Map.of("kind", i % 2 == 0 ? "even" : "odd"));
+                }
+                Edge template = tx.createEdge(
+                        tx.createNode(List.of("X")).id(),
+                        tx.createNode(List.of("X")).id(), "REL");
+                tx.setEdgeProperty(template.id(), "weight", 7);
+                tx.commit();
+            }
+            db.createNodePropertyIndex("Item", "kind");
+            db.createEdgePropertyIndex("REL", "weight");
+            try (Transaction tx = db.beginRead()) {
+                List<Long> evens = tx.findNodesByLabelProperty("Item", "kind", "even", 100);
+                assertEquals(3, evens.size());
+                assertEquals(1,
+                        tx.findEdgesByTypeProperty("REL", "weight", 7, 100).size());
+            }
+            db.dropNodePropertyIndex("Item", "kind");
+            try (Transaction tx = db.beginRead()) {
+                // Index dropped: lookup must now report unsupported.
+                LatticeException ex = assertThrows(LatticeException.class,
+                        () -> tx.findNodesByLabelProperty("Item", "kind", "even", 100));
+                assertEquals(ErrorCode.UNSUPPORTED, ex.getErrorCode());
+            }
+            db.dropEdgePropertyIndex("REL", "weight");
+        }
+    }
+
+    @Test
+    void getNodesByLabelAndAllNodes() {
+        try (Database db = Database.open(dir.resolve("l.db").toString(),
+                OpenOptions.defaults().create(true))) {
+            db.write(tx -> {
+                tx.createNode(List.of("A"));
+                tx.createNode(List.of("B"));
+                tx.createNode(List.of("A"));
+                return null;
+            });
+            assertEquals(2, db.getNodesByLabel("A").size());
+            assertEquals(0, db.getNodesByLabel("Nope").size());
+            assertEquals(1, db.getNodesByLabel("B").size());
+        }
+    }
+
+    @Test
+    void readOnlyTransactionRejectsWrites() {
+        try (Database db = Database.open(dir.resolve("ro.db").toString(),
+                OpenOptions.defaults().create(true))) {
+            try (Transaction tx = db.beginRead()) {
+                LatticeException ex = assertThrows(LatticeException.class,
+                        () -> tx.createNode(List.of("P")));
+                assertEquals(ErrorCode.READ_ONLY, ex.getErrorCode());
+                ex = assertThrows(LatticeException.class, () -> tx.setProperty(1, "k", 1));
+                assertEquals(ErrorCode.READ_ONLY, ex.getErrorCode());
+                // reads still fine
+                assertFalse(tx.nodeExists(9999));
+            }
+        }
+    }
+
+    @Test
+    void inactiveTransactionRejected() {
+        try (Database db = Database.open(dir.resolve("in.db").toString(),
+                OpenOptions.defaults().create(true));
+             Transaction tx = db.beginWrite()) {
+            tx.commit();
+            LatticeException ex = assertThrows(LatticeException.class,
+                    () -> tx.createNode(List.of("P")));
+            assertEquals(ErrorCode.TXN_ABORTED, ex.getErrorCode());
+        }
+    }
+
+    @Test
+    void rollbackDiscardsChanges() {
+        try (Database db = Database.open(dir.resolve("rb.db").toString(),
+                OpenOptions.defaults().create(true))) {
+            try (Transaction tx = db.beginWrite()) {
+                tx.createNode(List.of("T"));
+                tx.rollback();
+            }
+            long count = db.read(t ->
+                    (long) t.query("MATCH (n:T) RETURN count(n) AS c")
+                            .rows().get(0).get("c"));
+            assertEquals(0L, count);
+        }
+    }
+
+    @Test
+    void optionalImportUsedConsistently() {
+        // sanity: getNode returns Optional
+        try (Database db = Database.open(dir.resolve("o.db").toString(),
+                OpenOptions.defaults().create(true))) {
+            try (Transaction tx = db.beginRead()) {
+                Optional<Node> empty = tx.getNode(12345);
+                assertTrue(empty.isEmpty());
+            }
+        }
+    }
+}

--- a/bindings/java/src/test/java/io/latticedb/QueryTest.java
+++ b/bindings/java/src/test/java/io/latticedb/QueryTest.java
@@ -1,0 +1,129 @@
+package io.latticedb;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class QueryTest {
+    @TempDir
+    Path dir;
+
+    private Database seeded(String name) {
+        Database db = Database.open(dir.resolve(name).toString(),
+                OpenOptions.defaults().create(true).enableVectors(true).vectorDimensions(4));
+        db.write(tx -> {
+            Node alice = tx.createNode(List.of("Person"), Map.of("name", "Alice"));
+            Node bob = tx.createNode(List.of("Person"), Map.of("name", "Bob"));
+            tx.createEdge(alice.id(), bob.id(), "KNOWS");
+            tx.setVector(alice.id(), "embedding", new float[]{1, 0, 0, 0});
+            return null;
+        });
+        return db;
+    }
+
+    @Test
+    void parameterizedMatchQuery() {
+        try (Database db = seeded("q.db")) {
+            QueryResult result = db.query(
+                    "MATCH (a:Person)-[:KNOWS]->(b:Person) WHERE a.name = $name RETURN b.name AS other",
+                    Map.of("name", "Alice"));
+            assertEquals(List.of("other"), result.columns());
+            assertEquals(1, result.rows().size());
+            assertEquals("Bob", result.rows().get(0).get("other"));
+        }
+    }
+
+    @Test
+    void vectorParameterQuery() {
+        try (Database db = seeded("qv.db")) {
+            QueryResult result = db.query(
+                    "MATCH (n:Person) WHERE n.embedding <=> $v < 0.5 RETURN n.name AS name",
+                    Map.of("v", new float[]{1, 0, 0, 0}));
+            assertFalse(result.rows().isEmpty());
+        }
+    }
+
+    @Test
+    void writeQueryAutoSelectsWriteTransaction() {
+        try (Database db = seeded("wq.db")) {
+            QueryResult result = db.query(
+                    "CREATE (n:Created {tag: $t}) RETURN n.tag AS tag",
+                    Map.of("t", "yes"));
+            assertEquals("yes", result.rows().get(0).get("tag"));
+            long count = db.read(tx -> (long) tx.query(
+                    "MATCH (n:Created) RETURN count(n) AS c").rows().get(0).get("c"));
+            assertEquals(1L, count);
+        }
+    }
+
+    @Test
+    void parseErrorCarriesLocation() {
+        try (Database db = seeded("pe.db")) {
+            QueryException ex = assertThrows(QueryException.class,
+                    () -> db.query("MATCH (n RETURN n"));
+            assertEquals(QueryErrorStage.PARSE, ex.getStage());
+            assertTrue(ex.getMessage().contains("MATCH") || !ex.getMessage().isEmpty());
+        }
+    }
+
+    @Test
+    void semanticErrorHasStage() {
+        try (Database db = seeded("se.db")) {
+            QueryException ex = assertThrows(QueryException.class,
+                    () -> db.query("MATCH (n) RETURN bogus_function(n) AS x"));
+            // Unknown functions surface after parse (semantic or execution).
+            assertNotEquals(QueryErrorStage.PARSE, ex.getStage());
+            assertNotEquals(QueryErrorStage.NONE, ex.getStage());
+        }
+    }
+
+    @Test
+    void queryInsideExplicitTransaction() {
+        try (Database db = seeded("tx.db");
+             Transaction tx = db.beginRead()) {
+            QueryResult result = tx.query("MATCH (a)-[:KNOWS]->(b) RETURN b.name AS n",
+                    null);
+            assertEquals("Bob", result.rows().get(0).get("n"));
+        }
+    }
+
+    @Test
+    void cacheStatsAndClear() {
+        try (Database db = seeded("cs.db")) {
+            db.cacheClear();
+            db.query("MATCH (n:Person) RETURN count(n) AS c");
+            db.query("MATCH (n:Person) RETURN count(n) AS c");
+            QueryCacheStats stats = db.cacheStats();
+            assertTrue(stats.entries() > 0);
+            assertTrue(stats.hits() >= 1);
+            db.cacheClear();
+            assertEquals(0, db.cacheStats().entries());
+        }
+    }
+
+    @Test
+    void aggregationQuery() {
+        try (Database db = Database.open(dir.resolve("agg.db").toString(),
+                OpenOptions.defaults().create(true))) {
+            db.write(tx -> {
+                Node alice = tx.createNode(List.of("Person"), Map.of("name", "Alice"));
+                for (int i = 0; i < 3; i++) {
+                    Node doc = tx.createNode(List.of("Doc"), Map.of("title", "d" + i));
+                    tx.createEdge(doc.id(), alice.id(), "AUTHORED_BY");
+                }
+                return null;
+            });
+            QueryResult stats = db.query("""
+                    MATCH (doc:Document0)-[:AUTHORED_BY]->(p:Person)
+                    RETURN p.name AS name, count(doc) AS papers
+                    """.replace("Document0", "Doc"));
+            assertEquals(1, stats.rows().size());
+            assertEquals(3L, ((Number) stats.rows().get(0).get("papers")).longValue());
+        }
+    }
+}

--- a/bindings/java/src/test/java/io/latticedb/SearchTest.java
+++ b/bindings/java/src/test/java/io/latticedb/SearchTest.java
@@ -1,0 +1,104 @@
+package io.latticedb;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SearchTest {
+    @TempDir
+    Path dir;
+
+    @Test
+    void vectorSearchFindsExactMatch() {
+        try (Database db = Database.open(dir.resolve("v.db").toString(),
+                OpenOptions.defaults().create(true).enableVectors(true).vectorDimensions(4))) {
+            long target = db.write(tx -> tx.batchInsertVectors("Vec", new float[][]{
+                    {1, 0, 0, 0},
+                    {0, 1, 0, 0},
+                    {0, 0, 1, 0},
+            })).get(0);
+
+            List<VectorSearchResult> results = db.vectorSearch(
+                    new float[]{1, 0, 0, 0}, VectorSearchOptions.defaults().k(2));
+            assertFalse(results.isEmpty());
+            assertEquals(target, results.get(0).nodeId());
+            assertTrue(Math.abs(results.get(0).distance()) < 1e-3);
+        }
+    }
+
+    @Test
+    void vectorSearchInTransaction() {
+        try (Database db = Database.open(dir.resolve("vt.db").toString(),
+                OpenOptions.defaults().create(true).enableVectors(true).vectorDimensions(2))) {
+            db.write(tx -> {
+                Node n = tx.createNode(List.of("V"));
+                tx.setVector(n.id(), "embedding", new float[]{0.5f, 0.5f});
+                List<VectorSearchResult> hits =
+                        tx.queryVector(new float[]{0.5f, 0.5f}, 1, 0);
+                assertEquals(1, hits.size());
+                assertEquals(n.id(), hits.get(0).nodeId());
+                return null;
+            });
+        }
+    }
+
+    @Test
+    void batchInsertVectors() {
+        try (Database db = Database.open(dir.resolve("b.db").toString(),
+                OpenOptions.defaults().create(true).enableVectors(true).vectorDimensions(3))) {
+            List<Long> ids = db.write(tx ->
+                    tx.batchInsertVectors("Bulk", new float[][]{{1, 1, 1}, {2, 2, 2}, {3, 3, 3}}));
+            assertEquals(3, ids.size());
+            assertEquals(3, db.getNodesByLabel("Bulk").size());
+        }
+    }
+
+    @Test
+    void ftsSearchAndFuzzy() {
+        try (Database db = Database.open(dir.resolve("f.db").toString(),
+                OpenOptions.defaults().create(true))) {
+            db.write(tx -> {
+                Node a = tx.createNode(List.of("Doc"));
+                tx.ftsIndex(a.id(), "The quick brown fox jumps over the lazy dog");
+                Node b = tx.createNode(List.of("Doc"));
+                tx.ftsIndex(b.id(), "Completely different words appear here");
+                return null;
+            });
+
+            List<FTSSearchResult> hits = db.ftsSearch("quick fox",
+                    FTSSearchOptions.defaults());
+            assertEquals(1, hits.size());
+            assertEquals(1, hits.get(0).nodeId());
+            assertTrue(hits.get(0).score() > 0);
+
+            // typo tolerance: "quck" should match via fuzzy search
+            List<FTSSearchResult> fuzzy = db.ftsSearchFuzzy("quck fox",
+                    FTSSearchOptions.defaults());
+            assertFalse(fuzzy.isEmpty());
+
+            // A null options value consistently selects binding defaults.
+            assertFalse(db.ftsSearchFuzzy("quck fox", null).isEmpty());
+            try (Transaction tx = db.beginRead()) {
+                assertFalse(tx.ftsSearchFuzzy("quck fox", null).isEmpty());
+            }
+
+            List<FTSSearchResult> none = db.ftsSearch("zebra",
+                    FTSSearchOptions.defaults());
+            assertTrue(none.isEmpty());
+        }
+    }
+
+    @Test
+    void hashEmbedIsDeterministic() {
+        float[] a = Embedding.hashEmbed("hello", 16);
+        float[] b = Embedding.hashEmbed("hello", 16);
+        assertEquals(16, a.length);
+        assertArrayEquals(a, b);
+        assertFalse(java.util.Arrays.equals(a, Embedding.hashEmbed("world", 16)),
+                "different inputs must produce different embeddings");
+    }
+}

--- a/bindings/java/src/test/java/io/latticedb/StreamTest.java
+++ b/bindings/java/src/test/java/io/latticedb/StreamTest.java
@@ -1,0 +1,87 @@
+package io.latticedb;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class StreamTest {
+    @TempDir
+    Path dir;
+
+    @Test
+    void publishReadOffsetTrim() {
+        try (Database db = Database.open(dir.resolve("s.db").toString(),
+                OpenOptions.defaults().create(true))) {
+            long last = db.write(tx -> {
+                tx.publishStream("events", null, Map.of("i", 1));
+                tx.publishStream("events", "custom", List.of("a", "b"));
+                long seq = tx.publishStreamGetSequence("events", null, Map.of("i", 3));
+                return seq;
+            });
+            assertEquals(3L, last);
+
+            List<StreamRecord> records = db.readStream("events", 0, 10, 0);
+            assertEquals(3, records.size());
+            assertEquals(1L, records.get(0).sequence());
+            assertEquals("message", records.get(0).kind());
+            assertEquals(Map.of("i", 1L), records.get(0).payload());
+            assertEquals("custom", records.get(1).kind());
+
+            // cursor semantics: read after sequence 1 yields the remainder
+            List<StreamRecord> tail = db.readStream("events", 1, 10, 0);
+            assertEquals(2, tail.size());
+
+            assertTrue(db.getStreamOffset("events", "c1").isEmpty());
+            db.write(tx -> {
+                tx.setStreamOffset("events", "c1", records.get(records.size() - 1).sequence());
+                return null;
+            });
+            assertEquals(3L, db.getStreamOffset("events", "c1").orElseThrow());
+
+            assertEquals(3L, db.getLastSequence("events"));
+
+            db.write(tx -> {
+                tx.trimStream("events", 2);
+                return null;
+            });
+            List<StreamRecord> remaining = db.readStream("events", 0, 10, 0);
+            assertEquals(1, remaining.size());
+            assertEquals(3L, remaining.get(0).sequence());
+        }
+    }
+
+    @Test
+    void changefeedReflectsGraphWrites() {
+        try (Database db = Database.open(dir.resolve("c.db").toString(),
+                OpenOptions.defaults().create(true))) {
+            db.write(tx -> {
+                Node a = tx.createNode(List.of("P"), Map.of("name", "Alice"));
+                Node b = tx.createNode(List.of("P"));
+                tx.createEdge(a.id(), b.id(), "KNOWS");
+                return null;
+            });
+
+            List<StreamRecord> changes = db.changes(0, 100, 0);
+            assertFalse(changes.isEmpty());
+            assertTrue(changes.stream().allMatch(r -> r.kind() != null));
+        }
+    }
+
+    @Test
+    void reservedPrefixRejected() {
+        try (Database db = Database.open(dir.resolve("r.db").toString(),
+                OpenOptions.defaults().create(true))) {
+            LatticeException ex = assertThrows(LatticeException.class,
+                    () -> db.write(tx -> {
+                        tx.publishStream("__lattice_forbidden", null, "x");
+                        return null;
+                    }));
+            assertEquals(ErrorCode.INVALID_ARG, ex.getErrorCode());
+        }
+    }
+}

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -12,6 +12,7 @@ Use this path if you want the fastest route to a working example:
 | Python | local apps, scripts, notebooks | [../bindings/python/README.md](../bindings/python/README.md) |
 | TypeScript | Node.js services and tooling | [../bindings/typescript/README.md](../bindings/typescript/README.md) |
 | Go | cgo-backed native client | [../bindings/go/README.md](../bindings/go/README.md) |
+| Java | JVM applications using JNI | [../bindings/java/README.md](../bindings/java/README.md) |
 
 For a larger graph/vector/text demo, see [../examples/README.md](../examples/README.md).
 
@@ -67,6 +68,7 @@ $LATTICE check /tmp/lattice-quickstart.lattice
 - Published Python wheels are expected to bundle `liblattice` on supported platforms.
 - Published TypeScript package tarballs are expected to bundle `liblattice` on supported platforms.
 - Go currently uses an installed-prefix or repo-local shared-library workflow rather than bundled native artifacts.
+- Java currently compiles its JNI bridge and stages `liblattice` from a source checkout during the Maven build.
 
 If you are developing from a source checkout, see the binding READMEs for staged-library and installed-prefix workflows.
 


### PR DESCRIPTION
## Summary

- add Java 21 bindings over the stable C API through a JNI bridge
- cover database and transaction lifecycle, graph CRUD/traversal, properties and indexes, Cypher queries, vector/full-text search, durable streams, query-cache diagnostics, and embedding helpers
- add a Maven build that compiles and stages the native libraries on Linux and macOS
- document the Java API and include a runnable knowledge-graph example
- run the Java suite in CI on Ubuntu and macOS

## Implementation disclosure

The Java binding was produced with AI assistance. Before opening this PR, the generated implementation was reviewed and corrected for clean-build reproducibility, Linux/macOS portability, JNI reference and allocation safety, API edge cases, documentation accuracy, and example execution.

## Testing

- Maven clean test: 33 tests passed, covering lifecycle/read-only behavior and rollback, node/edge operations, nested values and large collections, property indexes, query parameters and diagnostics, vector and full-text search, streams/changefeeds, and query-cache behavior
- repository Zig suite: 749 tests passed and 5 skipped (7/7 build steps succeeded)
- JNI bridge compiled with additional warning checks
- documented knowledge-graph example executed successfully against the staged native library

The Java CI matrix exercises clean Maven builds on both Ubuntu and macOS so the native staging and platform-specific loader configuration stay covered.
